### PR TITLE
Clarify wording in error messages esp. TLDR005

### DIFF
--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -6,7 +6,7 @@ module.exports.ERRORS = parser.ERRORS = {
   'TLDR002': 'A single space should precede a sentence',
   'TLDR003': 'Descriptions should start with a capital letter',
   'TLDR004': 'Command descriptions should end in a period',
-  'TLDR005': 'Example descriptions should end in a colon',
+  'TLDR005': 'Example descriptions should end in a colon with no trailing characters',
   'TLDR006': 'Command name and description should be separated by an empty line',
   'TLDR007': 'Example descriptions should be surrounded by empty lines',
   'TLDR008': 'File should contain no trailing whitespace',

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -13,7 +13,7 @@ module.exports.ERRORS = parser.ERRORS = {
   'TLDR009': 'Page should contain a newline at end of file',
   'TLDR010': 'Only Unix-style line endings allowed',
   'TLDR011': 'Page never contains more than a single empty line',
-  'TLDR012': 'Page should contains no tabs',
+  'TLDR012': 'Page should contain no tabs',
   'TLDR013': 'Title should be alphanumeric with dashes, underscores or spaces',
   'TLDR014': 'Page should contain no trailing whitespace',
 


### PR DESCRIPTION
[This](https://github.com/tldr-pages/tldr/pull/1094) pull request on tldr had a failing lint test because of trailing white space, but the error message only specified that the description must end with a colon. 

This pull request clarifies what the lint is really checking for.