### PR TITLE
ci(dependabot): add Dependabot for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Our dependencies are way behind, so I feel like it might be best to sort this before adding Dependabot. 🤔

I think for now we probably only really need to update `commander` and `jison`. And then in future we can move away from Grunt to npm scripts. 👍🏻