### PR TITLE
chore(npm): bump dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exec": "^0.4.6",
-    "grunt-jasmine-nodejs": "^1.4.3",
-    "jasmine-core": "^2.4.1",
-    "jasmine-node": "^1.14.5",
+    "grunt-jasmine-nodejs": "^1.6.1",
+    "jasmine-core": "^3.6.0",
+    "jasmine-node": "^3.0.0",
     "jison": "^0.4.18"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "commander": "^2.9.0"
+    "commander": "^6.1.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-jasmine-nodejs": "^1.4.3",
     "jasmine-core": "^2.4.1",
     "jasmine-node": "^1.14.5",
-    "jison": "^0.4.15"
+    "jison": "^0.4.18"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
I think we can leave the Grunt package versions for now, as it's probably worth moving away from Grunt in future. 👍🏻