### PR TITLE
chore: prepare package for npm release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -36,5 +36,11 @@
     "jasmine-core": "^2.4.1",
     "jasmine-node": "^1.14.5",
     "jison": "^0.4.15"
-  }
+  },
+  "files": [
+    "lib/",
+    "specs/",
+    "tldr.l",
+    "tldr.yy"
+  ]
 }


### PR DESCRIPTION
This PR stops the `package-lock.json` being tracked in Git to prevent accidental commits.

It also adds a `files` key to the `package.json` which makes it easier to manage the files that should be included in the release (`package.json`, `LICENSE.md`, and `README.md` are all included by default). 👍🏻