### PR TITLE
Parse and lint the homepage line

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ TLDR012     | Page should contain no tabs
 TLDR013     | Title should be alphanumeric with dashes, underscores or spaces
 TLDR014     | Page should contain no trailing whitespace
 TLDR015     | Example descriptions should start with a capital letter
+TLDR016     | Homepage prefix should be spelled exactly "More information: "
+TLDR017     | Homepage URL should be surrounded with angle brackets
 TLDR101     | Command description probably not properly annotated
 TLDR102     | Example description probably not properly annotated
 TLDR103     | Command example is missing its closing backtick

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -17,6 +17,8 @@ module.exports.ERRORS = parser.ERRORS = {
   'TLDR013': 'Title should be alphanumeric with dashes, underscores or spaces',
   'TLDR014': 'Page should contain no trailing whitespace',
   'TLDR015': 'Example descriptions should start with a capital letter',
+  'TLDR016': 'Homepage prefix should be spelled exactly "More information: "',
+  'TLDR017': 'Homepage URL should be surrounded with angle brackets',
 
   'TLDR101': 'Command description probably not properly annotated',
   'TLDR102': 'Example description probably not properly annotated',
@@ -32,6 +34,7 @@ module.exports.ERRORS = parser.ERRORS = {
     this.yy.errors = []
     this.yy.page = {
       description: [],    // can be multiple lines
+      moreInformation: null,
       examples: []
     };
   };
@@ -54,6 +57,9 @@ module.exports.ERRORS = parser.ERRORS = {
   };
   parser.yy.addDescription = function(description) {
     parser.yy.page.description.push(description);
+  };
+  parser.yy.addMoreInformation = function(url) {
+    parser.yy.page.moreInformation = url;
   };
   parser.yy.addExample = function(description, commands) {
     parser.yy.page.examples.push({
@@ -121,6 +127,10 @@ linter.format = function(parsedPage) {
     str += util.format('> %s', linter.formatDescription(line));
     str += '\n';
   });
+  if (parsedPage.moreInformation) {
+    str += util.format('> More information: %s.', parsedPage.moreInformation);
+    str += '\n';
+  }
   parsedPage.examples.forEach(function(example) {
     str += '\n';
     str += util.format('- %s', linter.formatExampleDescription(example.description));

--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -72,12 +72,12 @@
   }
 */
 var tldrParser = (function(){
-var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o},$V0=[1,7],$V1=[5,11],$V2=[1,5,8,17],$V3=[2,8],$V4=[1,12],$V5=[8,17],$V6=[2,11],$V7=[1,18],$V8=[1,5,8,11,17],$V9=[5,20],$Va=[1,27],$Vb=[1,5,8,17,20],$Vc=[20,22,23];
+var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o},$V0=[1,8],$V1=[5,13],$V2=[1,5,8,23],$V3=[2,12],$V4=[8,23],$V5=[2,15],$V6=[1,20],$V7=[1,5,8,13,23],$V8=[5,26],$V9=[1,33],$Va=[1,5,8,23,26],$Vb=[26,28,29];
 var parser = {trace: function trace () { },
 yy: {},
-symbols_: {"error":2,"page":3,"title":4,"NEWLINE":5,"description":6,"examples":7,"TEXT":8,"HASH":9,"TITLE":10,"GREATER_THAN":11,"DESCRIPTION_LINE":12,"example":13,"maybe_newline":14,"example_description":15,"example_commands":16,"DASH":17,"EXAMPLE_DESCRIPTION":18,"example_command":19,"BACKTICK":20,"example_command_inner":21,"COMMAND_TEXT":22,"COMMAND_TOKEN":23,"$accept":0,"$end":1},
-terminals_: {2:"error",5:"NEWLINE",8:"TEXT",9:"HASH",10:"TITLE",11:"GREATER_THAN",12:"DESCRIPTION_LINE",17:"DASH",18:"EXAMPLE_DESCRIPTION",20:"BACKTICK",22:"COMMAND_TEXT",23:"COMMAND_TOKEN"},
-productions_: [0,[3,4],[3,3],[3,4],[4,2],[4,1],[6,2],[6,3],[7,0],[7,2],[13,4],[14,0],[14,1],[15,2],[15,1],[16,1],[16,2],[19,3],[21,0],[21,2],[21,2]],
+symbols_: {"error":2,"page":3,"title":4,"NEWLINE":5,"info":6,"examples":7,"TEXT":8,"HASH":9,"TITLE":10,"description":11,"more_information":12,"GREATER_THAN":13,"DESCRIPTION_LINE":14,"MORE_INFORMATION":15,"ANGLE_BRACKETED_URL":16,"END_MORE_INFORMATION_URL":17,"END_MORE_INFORMATION":18,"example":19,"maybe_newline":20,"example_description":21,"example_commands":22,"DASH":23,"EXAMPLE_DESCRIPTION":24,"example_command":25,"BACKTICK":26,"example_command_inner":27,"COMMAND_TEXT":28,"COMMAND_TOKEN":29,"$accept":0,"$end":1},
+terminals_: {2:"error",5:"NEWLINE",8:"TEXT",9:"HASH",10:"TITLE",13:"GREATER_THAN",14:"DESCRIPTION_LINE",15:"MORE_INFORMATION",16:"ANGLE_BRACKETED_URL",17:"END_MORE_INFORMATION_URL",18:"END_MORE_INFORMATION",23:"DASH",24:"EXAMPLE_DESCRIPTION",26:"BACKTICK",28:"COMMAND_TEXT",29:"COMMAND_TOKEN"},
+productions_: [0,[3,4],[3,3],[3,4],[4,2],[4,1],[6,1],[6,2],[11,2],[11,3],[12,4],[12,3],[7,0],[7,2],[19,4],[20,0],[20,1],[21,2],[21,1],[22,1],[22,2],[25,3],[27,0],[27,2],[27,2]],
 performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
 /* this == yyval */
 
@@ -95,10 +95,16 @@ break;
 case 5:
 this.$ = yy.error(_$[$0], 'TLDR106') || yy.setTitle($$[$0]);
 break;
-case 6: case 7:
+case 8: case 9:
 this.$ = yy.addDescription($$[$0]);
 break;
 case 10:
+this.$ = yy.addMoreInformation($$[$0-1]);
+break;
+case 11:
+this.$ = yy.error(this._$, 'TLDR017') || yy.addDescription($$[$0-1] + $$[$0].trim());
+break;
+case 14:
  
               yy.addExample($$[$0-2], $$[$0]);
               // Just use the description line's location, easy to find
@@ -108,33 +114,33 @@ case 10:
                 yy.error(_$[$0], 'TLDR007');
             
 break;
-case 13:
+case 17:
 this.$ = $$[$0];
 break;
-case 14:
+case 18:
 this.$ = yy.error(this._$, 'TLDR102') || $$[$0];
 break;
-case 15:
+case 19:
 this.$ = [$$[$0]];
 break;
-case 16:
+case 20:
 this.$ = yy.error(_$[$0], 'TLDR105') || $$[$0-1];
 break;
-case 17:
+case 21:
 this.$ = $$[$0-1];
 break;
-case 18:
+case 22:
 this.$ = [];
 break;
-case 19:
+case 23:
 this.$ = [].concat($$[$0-1], yy.createCommandText($$[$0]));
 break;
-case 20:
+case 24:
 this.$ = [].concat($$[$0-1], yy.createToken($$[$0]));
 break;
 }
 },
-table: [{3:1,4:2,8:[1,4],9:[1,3]},{1:[3]},{5:[1,5],6:6,11:$V0},{10:[1,8]},o($V1,[2,5]),{6:9,8:[1,10],11:$V0},o($V2,$V3,{7:11,11:$V4}),{12:[1,13]},o($V1,[2,4]),o($V2,$V3,{7:14,11:$V4}),o($V2,$V3,{7:15}),o($V5,$V6,{13:16,14:17,1:[2,2],5:$V7}),{12:[1,19]},o($V8,[2,6]),o($V5,$V6,{13:16,14:17,1:[2,1],5:$V7}),o($V5,$V6,{13:16,14:17,1:[2,3],5:$V7}),o($V2,[2,9]),{8:[1,22],15:20,17:[1,21]},o([8,17,20],[2,12]),o($V8,[2,7]),{5:$V7,14:23,20:$V6},{18:[1,24]},o($V9,[2,14]),{16:25,19:26,20:$Va},o($V9,[2,13]),o($V2,[2,10],{19:28,20:$Va}),o($Vb,[2,15]),o($Vc,[2,18],{21:29}),o($Vb,[2,16]),{20:[1,30],22:[1,31],23:[1,32]},o($Vb,[2,17]),o($Vc,[2,19]),o($Vc,[2,20])],
+table: [{3:1,4:2,8:[1,4],9:[1,3]},{1:[3]},{5:[1,5],6:6,11:7,13:$V0},{10:[1,9]},o($V1,[2,5]),{6:10,8:[1,11],11:7,13:$V0},o($V2,$V3,{7:12}),o($V2,[2,6],{12:13,13:[1,14]}),{14:[1,15]},o($V1,[2,4]),o($V2,$V3,{7:16}),o($V2,$V3,{7:17}),o($V4,$V5,{19:18,20:19,1:[2,2],5:$V6}),o($V2,[2,7]),{14:[1,21],15:[1,22]},o($V7,[2,8]),o($V4,$V5,{19:18,20:19,1:[2,1],5:$V6}),o($V4,$V5,{19:18,20:19,1:[2,3],5:$V6}),o($V2,[2,13]),{8:[1,25],21:23,23:[1,24]},o([8,23,26],[2,16]),o($V7,[2,9]),{16:[1,26],18:[1,27]},{5:$V6,20:28,26:$V5},{24:[1,29]},o($V8,[2,18]),{17:[1,30]},o($V2,[2,11]),{22:31,25:32,26:$V9},o($V8,[2,17]),o($V2,[2,10]),o($V2,[2,14],{25:34,26:$V9}),o($Va,[2,19]),o($Vb,[2,22],{27:35}),o($Va,[2,20]),{26:[1,36],28:[1,37],29:[1,38]},o($Va,[2,21]),o($Vb,[2,23]),o($Vb,[2,24])],
 defaultActions: {},
 parseError: function parseError (str, hash) {
     if (hash.recoverable) {
@@ -658,26 +664,59 @@ case 4:
   }
   if (this.matches[1] == '>') {
     this.pushState('description');
-    return 11;
+    return 13;
   } else {
     this.pushState('example_description');
-    return 17;
+    return 23;
   }
 
 break;
 case 5:
+  if (this.topState() !== 'description') {
+    this.reject();
+    return;
+  }
+  if (this.matches[1] !== 'More information: ') {
+    console.log(this.matches[1])
+    yy.error(yy_.yylloc, 'TLDR016');
+  }
+  this.popState();
+  this.pushState('more_information');
+  return 15;
+
+break;
+case 6:
+  if (this.topState() !== 'more_information') {
+    this.reject();
+    return;
+  }
+  this.popState();
+  this.pushState('more_information_url');
+  return 16;
+
+break;
+case 7:
   if (this.topState() === "title") {
     yy_.yytext = this.matches[1];
     if (this.matches[1].match(/([^A-Za-z0-9_\. -])|(\.$)/)) yy.error(yy_.yylloc, 'TLDR013');
     this.checkNewline(this.matches[2], yy_.yylloc);
     this.popState();
     return 10;
+  } else if (this.topState() === "more_information_url") {
+    if (this.matches[1] != '.') yy.error(yy_.yylloc, 'TLDR004');
+    this.checkNewline(this.matches[2], yy_.yylloc);
+    this.popState();
+    return 17;
+  } else if (this.topState() === "more_information") {
+    this.checkNewline(this.matches[2], yy_.yylloc);
+    this.popState();
+    return 18;
   } else {
     this.reject();
   }
 
 break;
-case 6:
+case 8:
   if (this.topState() === 'description') {
     this.popState();
     yy_.yytext = this.matches[1];
@@ -695,13 +734,13 @@ case 6:
       console.warn('Description ends in\'', punctuation, '\'. Consider writing your sentence on one line.');
     }
     this.checkNewline(this.matches[4], yy_.yylloc);
-    return 12;
+    return 14;
   } else {
     this.reject();
   }
 
 break;
-case 7:
+case 9:
   if (this.topState() === 'example_description') {
     this.popState();
     yy_.yytext = this.matches[1];
@@ -713,28 +752,28 @@ case 7:
     // Check if any sneaky spaces have been caught
     if (this.matches[3] !== '') yy.error(yy_.yylloc, 'TLDR014');
     this.checkNewline(this.matches[3], yy_.yylloc);
-    return 18;
+    return 24;
   } else {
     this.reject();
   }
-
-break;
-case 8:
-  if (this.topState() === 'example_command') {
-    this.popState();
-    this.checkNewline(this.matches[1], yy_.yylloc);
-    return 20;
-  } else {
-    this.reject();
-  }
-
-break;
-case 9:
-  this.pushState('example_command');
-  return 20;
 
 break;
 case 10:
+  if (this.topState() === 'example_command') {
+    this.popState();
+    this.checkNewline(this.matches[1], yy_.yylloc);
+    return 26;
+  } else {
+    this.reject();
+  }
+
+break;
+case 11:
+  this.pushState('example_command');
+  return 26;
+
+break;
+case 12:
   if (this.topState() === 'example_command') {
     yy_.yytext = this.matches[1];
     if (this.matches[3]) {
@@ -743,19 +782,19 @@ case 10:
       this.unput('`' + this.matches[2]);
       yy.error(yy_.yylloc, 'TLDR103')
     }
-    return 23;
+    return 29;
   } else this.reject();
 
 break;
-case 11:
+case 13:
   if (this.topState() === 'example_command') {
     this.unput('{{');
     yy_.yytext = this.matches[1];
-    return 22;
+    return 28;
   } else this.reject();
 
 break;
-case 12:
+case 14:
   if (this.topState() === 'example_command') {
     // Check if there are some trailing spaces
     if (this.matches[2].match(/ /)) {
@@ -770,15 +809,15 @@ case 12:
       yy.error(yy_.yylloc, 'TLDR103')
     }
     yy_.yytext = this.matches[1];
-    return 22;
+    return 28;
   } else this.reject();
 
 break;
-case 13:
+case 15:
   yy.error(yy_.yylloc, 'TLDR014');
 
 break;
-case 14:
+case 16:
   // Either you've got more than a single \n or \r or more than \r\n
   var isdos = this.match.match(/\r\n/);
   if (isdos && this.match.length > 2 || !isdos && this.match.length > 1) {
@@ -788,15 +827,15 @@ case 14:
   return 5;
 
 break;
-case 15:
+case 17:
   yy_.yytext = this.matches[1];
   return 8;
 
 break;
 }
 },
-rules: [/^(?:\s+$)/,/^(?:.*?\t+.*)/,/^(?:[^\n]$)/,/^(?:(\s*)#(\s*))/,/^(?:([\>-])(\s*))/,/^(?:(.+)((?:\r\n)|\n|\r))/,/^(?:(.+?)([\.,;!\?]?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:(.+?)([\.:,;]?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:`((?:\r\n)|\n|\r))/,/^(?:`)/,/^(?:\{\{([^\n\`\{\}]*)\}\}(((?:\r\n)|\n|\r)?))/,/^(?:([^\`\n]+?)\{\{)/,/^(?:([^\`\n]+?)(`[ ]*|[ ]*((?:\r\n)|\n|\r)))/,/^(?:[ ]+)/,/^(?:((?:\r\n)|\n|\r)+)/,/^(?:(.+?)[\.:]?((?:\r\n)|\n|\r))/],
-conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"inclusive":true}}
+rules: [/^(?:\s+$)/,/^(?:.*?\t+.*)/,/^(?:[^\n]$)/,/^(?:(\s*)#(\s*))/,/^(?:([\>-])(\s*))/,/^(?:([Mm]ore\s+information:?\s*))/,/^(?:(<https?:\/\/[^\s\>]*>))/,/^(?:(.+)((?:\r\n)|\n|\r))/,/^(?:(.+?)([\.,;!\?]?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:(.+?)([\.:,;]?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:`((?:\r\n)|\n|\r))/,/^(?:`)/,/^(?:\{\{([^\n\`\{\}]*)\}\}(((?:\r\n)|\n|\r)?))/,/^(?:([^\`\n]+?)\{\{)/,/^(?:([^\`\n]+?)(`[ ]*|[ ]*((?:\r\n)|\n|\r)))/,/^(?:[ ]+)/,/^(?:((?:\r\n)|\n|\r)+)/,/^(?:(.+?)[\.:]?((?:\r\n)|\n|\r))/],
+conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17],"inclusive":true}}
 });
 return lexer;
 })();

--- a/specs/pages/016.md
+++ b/specs/pages/016.md
@@ -1,0 +1,8 @@
+# demo
+
+> Sample program.
+> more information <https://not.real.invalid>.
+
+- Run demo:
+
+`demo`

--- a/specs/pages/017.md
+++ b/specs/pages/017.md
@@ -1,0 +1,8 @@
+# demo
+
+> Sample program.
+> More information: https://not.real.invalid
+
+- Run demo:
+
+`demo`

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -84,6 +84,18 @@ describe("TLDR conventions", function() {
     expect(containsOnlyErrors(errors, 'TLDR015')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
+
+  it("TLDR016\t" + linter.ERRORS.TLDR016, function() {
+    var errors = lintFile('pages/016.md').errors;
+    expect(containsOnlyErrors(errors, 'TLDR016')).toBeTruthy();
+    expect(errors.length).toBe(1);
+  });
+
+  it("TLDR017\t" + linter.ERRORS.TLDR017, function() {
+    var errors = lintFile('pages/017.md').errors;
+    expect(containsOnlyErrors(errors, 'TLDR017')).toBeTruthy();
+    expect(errors.length).toBe(1);
+  });
 });
 
 describe("Common TLDR formatting errors", function() {

--- a/tldr.l
+++ b/tldr.l
@@ -68,6 +68,32 @@ space [ \t]
   }
 %}
 
+([Mm]ore\s+information\:?\s*)
+%{
+  if (this.topState() !== 'description') {
+    this.reject();
+    return;
+  }
+  if (this.matches[1] !== 'More information: ') {
+    console.log(this.matches[1])
+    yy.error(yylloc, 'TLDR016');
+  }
+  this.popState();
+  this.pushState('more_information');
+  return 'MORE_INFORMATION';
+%}
+
+(\<https?\:\/\/[^\s\>]*\>)
+%{
+  if (this.topState() !== 'more_information') {
+    this.reject();
+    return;
+  }
+  this.popState();
+  this.pushState('more_information_url');
+  return 'ANGLE_BRACKETED_URL';
+%}
+
 // All regexes below are actually about the same, but it's better organized
 // this way around.
 (.+){eol}
@@ -78,6 +104,15 @@ space [ \t]
     this.checkNewline(this.matches[2], yylloc);
     this.popState();
     return 'TITLE';
+  } else if (this.topState() === "more_information_url") {
+    if (this.matches[1] != '.') yy.error(yylloc, 'TLDR004');
+    this.checkNewline(this.matches[2], yylloc);
+    this.popState();
+    return 'END_MORE_INFORMATION_URL';
+  } else if (this.topState() === "more_information") {
+    this.checkNewline(this.matches[2], yylloc);
+    this.popState();
+    return 'END_MORE_INFORMATION';
   } else {
     this.reject();
   }

--- a/tldr.yy
+++ b/tldr.yy
@@ -9,8 +9,8 @@
 
 %%
 
-page      : title NEWLINE description examples
-          | title description examples          -> yy.error(@$, 'TLDR006')
+page      : title NEWLINE info examples
+          | title info examples          -> yy.error(@$, 'TLDR006')
           | title NEWLINE TEXT examples         -> yy.error(@$, 'TLDR101') || yy.addDescription($TEXT);
           ;
 
@@ -18,9 +18,19 @@ title     : HASH TITLE  -> yy.setTitle($TITLE)
           | TEXT        -> yy.error(@TEXT, 'TLDR106') || yy.setTitle($TEXT)
           ;
 
+info  : description
+      | description more_information
+      ;
+
 description   : GREATER_THAN DESCRIPTION_LINE -> yy.addDescription($DESCRIPTION_LINE)
               | description GREATER_THAN DESCRIPTION_LINE -> yy.addDescription($DESCRIPTION_LINE)
               ;
+
+more_information  : GREATER_THAN MORE_INFORMATION ANGLE_BRACKETED_URL END_MORE_INFORMATION_URL
+                    -> yy.addMoreInformation($ANGLE_BRACKETED_URL)
+                  | GREATER_THAN MORE_INFORMATION END_MORE_INFORMATION
+                    -> yy.error(@$, 'TLDR017') || yy.addDescription($MORE_INFORMATION + $END_MORE_INFORMATION.trim())
+                  ;
 
 examples  : %empty
           | examples example


### PR DESCRIPTION
Expected format is as follows:

```
> More information: <http://some.site.invalid/>.
```
---

I missed the correct format when writing tldr pages and was surprised that the linter showed no warnings. Here's an implementation.