### PR TITLE
feat: add check for max of 8 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ TLDR015     | Example descriptions should start with a capital letter
 TLDR016     | Label for information link should be spelled exactly `More information: `
 TLDR017     | Information link should be surrounded with angle brackets
 TLDR018     | Page should only include a single information link
+TLDR019     | Page should only include a maximum of 8 examples
 TLDR101     | Command description probably not properly annotated
 TLDR102     | Example description probably not properly annotated
 TLDR103     | Command example is missing its closing backtick

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -20,6 +20,7 @@ module.exports.ERRORS = parser.ERRORS = {
   'TLDR016': 'Label for information link should be spelled exactly `More information: `',
   'TLDR017': 'Information link should be surrounded with angle brackets',
   'TLDR018': 'Page should only include a single information link',
+  'TLDR019': 'Page should only include a maximum of 8 examples',
 
   'TLDR101': 'Command description probably not properly annotated',
   'TLDR102': 'Example description probably not properly annotated',
@@ -169,6 +170,10 @@ linter.process = function(page, verbose, alsoFormat) {
     errors: parser.yy.errors,
     success: success
   };
+
+  if (parser.yy.page.examples.length > 8) {
+    result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR019', 'description': this.ERRORS.TLDR019 })
+  }
 
   if (alsoFormat)
     result.formatted = linter.format(parser.yy.page);

--- a/specs/pages/019.md
+++ b/specs/pages/019.md
@@ -1,0 +1,40 @@
+# demo
+
+> Sample program.
+> More information: <https://not.real.invalid>.
+
+- Example 1:
+
+`demo`
+
+- Example 2:
+
+`demo`
+
+- Example 3:
+
+`demo`
+
+- Example 4:
+
+`demo`
+
+- Example 5:
+
+`demo`
+
+- Example 6:
+
+`demo`
+
+- Example 7:
+
+`demo`
+
+- Example 8:
+
+`demo`
+
+- Example 9:
+
+`demo`

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -102,6 +102,12 @@ describe("TLDR conventions", function() {
     expect(containsOnlyErrors(errors, 'TLDR018')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
+
+  it("TLDR019\t" + linter.ERRORS.TLDR019, function() {
+    var errors = lintFile('pages/019.md').errors;
+    expect(containsOnlyErrors(errors, 'TLDR019')).toBeTruthy();
+    expect(errors.length).toBe(1);
+  });
 });
 
 describe("Common TLDR formatting errors", function() {


### PR DESCRIPTION
I'm not entirely sure about this as I couldn't actually add it into the lexer files, so I've added it into the actual JS.

This looks a little bit odd, but seems to work like all the others. 👍🏻
https://github.com/owenvoke/tldr-lint/blob/0992dd3e5ba3b51f1252666e90516ce931ee8176/lib/tldr-lint.js#L175