### PR TITLE
ci: update tests to always use colour output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,5 @@ jobs:
 
     - run: npm i
     - run: npm run test
+      env:
+        FORCE_COLOR: true


### PR DESCRIPTION
This updates to force colour output in the test step, which makes the CI output much easier to read.