### PR TITLE
README: remove TODOs now tracked as issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Options:
   -h, --help           output usage information
 ```
 
-
 ## Linter errors
 
 All of the errors can be found in [`lib/tldr-lint.js`](./lib/tldr-lint.js).
@@ -55,11 +54,6 @@ TLDR103     | Command example is missing its closing backtick
 TLDR104     | Example descriptions should prefer infinitive tense (e.g. write) over present (e.g. writes) or gerund (e.g. writing)
 TLDR105     | There should be only one command per example
 TLDR106     | Page title should start with a hash (`#`)
-
-## To-do
-
-- Assert file has .md extension
-- Assert file name is same as page title
 
 [npm-url]: https://www.npmjs.com/package/tldr-lint
 [npm-image]: https://img.shields.io/npm/v/tldr-lint.svg


### PR DESCRIPTION
I just created #25 and #26 to track the TODO entries that were still in the README. The other items from the [original list](https://github.com/tldr-pages/tldr-lint/commit/e2b5156b9c1055019109736f653958e5f29952a4) have been removed as they were implemented.