### PR TITLE
Update Node versions in test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # todo: windows-latest
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
 
     name: Node ${{ matrix.node-version }} - ${{ matrix.os }}
 


### PR DESCRIPTION
Node v13 is EOL'd since June 2020, and v15 is the current version now (since October 2020). This change keeps tests running only in the supported Node versions (LTS), and the current one.