### PR TITLE
remove skipped test, duplicate of TLDR105

### DIFF
--- a/specs/pages/examples.md
+++ b/specs/pages/examples.md
@@ -1,9 +1,0 @@
-# du
-
-> Estimate file space usage.
-
-- Here goes an example:
-
-`there are really a lot of ways`
-`of doing {{this}}`
-`such a long list`

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -158,10 +158,4 @@ describe("TLDR pages that are simply correct", function() {
     var errors = lintFile('pages/bracket.md').errors;
     expect(errors.length).toBe(0);
   });
-
-  // deprecated
-  xit("Multiple example lines", function() {
-    var errors = lintFile('pages/examples.md').errors;
-    expect(errors.length).toBe(0);
-  });
 });


### PR DESCRIPTION
The deprecated/skipped test of `Multiple example lines` is the inverse of the test of `TLDR105` which ensures no multiple lines per example. Given that the lint rule has been in place for 5+ years and would seem unlikely to be removed, probably safe to remove this skipped test.

Both `specs/pages/examples.md` and `specs/pages/105.md` are mostly the same with the only difference being that `examples.md` has the last word of the second line wrapped as a token (`{{this}}`) while `105.md` does not. Not sure that's a meaningful difference as it does not trigger an error or anything.