### PR TITLE
fix: catch trailing spaces in title and information_link lines

### DIFF
--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -101,6 +101,12 @@ module.exports.ERRORS = parser.ERRORS = {
         parser.yy.error(locinfo, 'TLDR010')
       }
     };
+
+    lexer.checkTrailingWhitespace = function(nl, locinfo) {
+      if (nl !== '') {
+        parser.yy.error(locinfo, 'TLDR014');
+      }
+    }
   };
 })(parser);
 

--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -701,16 +701,19 @@ case 7:
   if (this.topState() === "title") {
     yy_.yytext = this.matches[1];
     if (this.matches[1].match(/([^A-Za-z0-9_\. -])|(\.$)/)) yy.error(yy_.yylloc, 'TLDR013');
-    this.checkNewline(this.matches[2], yy_.yylloc);
+    this.checkTrailingWhitespace(this.matches[2], yy_.yylloc);
+    this.checkNewline(this.matches[3], yy_.yylloc);
     this.popState();
     return 10;
   } else if (this.topState() === 'information_link_url') {
     if (this.matches[1] != '.') yy.error(yy_.yylloc, 'TLDR004');
-    this.checkNewline(this.matches[2], yy_.yylloc);
+    this.checkTrailingWhitespace(this.matches[2], yy_.yylloc);
+    this.checkNewline(this.matches[3], yy_.yylloc);
     this.popState();
     return 17;
   } else if (this.topState() === 'information_link') {
-    this.checkNewline(this.matches[2], yy_.yylloc);
+    this.checkTrailingWhitespace(this.matches[2], yy_.yylloc);
+    this.checkNewline(this.matches[3], yy_.yylloc);
     this.popState();
     return 18;
   } else {
@@ -729,12 +732,10 @@ case 8:
     if (punctuation !== '.') {
       yy.error(yy_.yylloc, 'TLDR004');
     }
-    if (this.matches[3] !== '') {
-      yy.error(yy_.yylloc, 'TLDR014');
-    }
     if (punctuation.match(/[,;]/)) {
       console.warn('Description ends in\'', punctuation, '\'. Consider writing your sentence on one line.');
     }
+    this.checkTrailingWhitespace(this.matches[3], yy_.yylloc);
     this.checkNewline(this.matches[4], yy_.yylloc);
     return 14;
   } else {
@@ -752,7 +753,7 @@ case 9:
       yy.error(yy_.yylloc, 'TLDR104');
     }
     // Check if any sneaky spaces have been caught
-    if (this.matches[3] !== '') yy.error(yy_.yylloc, 'TLDR014');
+    this.checkTrailingWhitespace(this.matches[3], yy_.yylloc);
     this.checkNewline(this.matches[3], yy_.yylloc);
     return 24;
   } else {
@@ -836,7 +837,7 @@ case 17:
 break;
 }
 },
-rules: [/^(?:\s+$)/,/^(?:.*?\t+.*)/,/^(?:[^\n]$)/,/^(?:(\s*)#(\s*))/,/^(?:([\>-])(\s*))/,/^(?:([Mm]ore\s+[Ii]nfo(?:rmation)?:?\s*))/,/^(?:(<https?:\/\/[^\s\>]*>))/,/^(?:(.+)((?:\r\n)|\n|\r))/,/^(?:(.+?)([\.,;!\?]?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:(.+?)([\.:,;]?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:`((?:\r\n)|\n|\r))/,/^(?:`)/,/^(?:\{\{([^\n\`\{\}]*)\}\}(((?:\r\n)|\n|\r)?))/,/^(?:([^\`\n]+?)\{\{)/,/^(?:([^\`\n]+?)(`[ ]*|[ ]*((?:\r\n)|\n|\r)))/,/^(?:[ ]+)/,/^(?:((?:\r\n)|\n|\r)+)/,/^(?:(.+?)[\.:]?((?:\r\n)|\n|\r))/],
+rules: [/^(?:\s+$)/,/^(?:.*?\t+.*)/,/^(?:[^\n]$)/,/^(?:(\s*)#(\s*))/,/^(?:([\>-])(\s*))/,/^(?:([Mm]ore\s+[Ii]nfo(?:rmation)?:?\s*))/,/^(?:(<https?:\/\/[^\s\>]*>))/,/^(?:(.+?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:(.+?)([\.,;!\?]?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:(.+?)([\.:,;]?)([ ]*)((?:\r\n)|\n|\r))/,/^(?:`((?:\r\n)|\n|\r))/,/^(?:`)/,/^(?:\{\{([^\n\`\{\}]*)\}\}(((?:\r\n)|\n|\r)?))/,/^(?:([^\`\n]+?)\{\{)/,/^(?:([^\`\n]+?)(`[ ]*|[ ]*((?:\r\n)|\n|\r)))/,/^(?:[ ]+)/,/^(?:((?:\r\n)|\n|\r)+)/,/^(?:(.+?)[\.:]?((?:\r\n)|\n|\r))/],
 conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17],"inclusive":true}}
 });
 return lexer;

--- a/specs/pages/014.md
+++ b/specs/pages/014.md
@@ -1,6 +1,7 @@
-# nix-env
+# nix-env 
 
 > Manipulate or query Nix user environments.    
+> More information: <https://docs.docker.com/engine/reference/commandline/container/>.  
 
 - Show the status of available packages:    
 

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -76,7 +76,7 @@ describe("TLDR conventions", function() {
   it("TLDR014\t" + linter.ERRORS.TLDR014, function() {
     var errors = lintFile('pages/014.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR014')).toBeTruthy();
-    expect(errors.length).toBe(3);
+    expect(errors.length).toBe(5);
   });
 
   it("TLDR015\t" + linter.ERRORS.TLDR015, function() {

--- a/tldr.l
+++ b/tldr.l
@@ -95,21 +95,24 @@ space [ \t]
 
 // All regexes below are actually about the same, but it's better organized
 // this way around.
-(.+){eol}
+(.+?)([ ]*){eol}
 %{
   if (this.topState() === "title") {
     yytext = this.matches[1];
     if (this.matches[1].match(/([^A-Za-z0-9_\. -])|(\.$)/)) yy.error(yylloc, 'TLDR013');
-    this.checkNewline(this.matches[2], yylloc);
+    this.checkTrailingWhitespace(this.matches[2], yylloc);
+    this.checkNewline(this.matches[3], yylloc);
     this.popState();
     return 'TITLE';
   } else if (this.topState() === 'information_link_url') {
     if (this.matches[1] != '.') yy.error(yylloc, 'TLDR004');
-    this.checkNewline(this.matches[2], yylloc);
+    this.checkTrailingWhitespace(this.matches[2], yylloc);
+    this.checkNewline(this.matches[3], yylloc);
     this.popState();
     return 'END_INFORMATION_LINK_URL';
   } else if (this.topState() === 'information_link') {
-    this.checkNewline(this.matches[2], yylloc);
+    this.checkTrailingWhitespace(this.matches[2], yylloc);
+    this.checkNewline(this.matches[3], yylloc);
     this.popState();
     return 'END_INFORMATION_LINK';
   } else {
@@ -129,12 +132,10 @@ space [ \t]
     if (punctuation !== '.') {
       yy.error(yylloc, 'TLDR004');
     }
-    if (this.matches[3] !== '') {
-      yy.error(yylloc, 'TLDR014');
-    }
     if (punctuation.match(/[,;]/)) {
       console.warn('Description ends in\'', punctuation, '\'. Consider writing your sentence on one line.');
     }
+    this.checkTrailingWhitespace(this.matches[3], yylloc);
     this.checkNewline(this.matches[4], yylloc);
     return 'DESCRIPTION_LINE';
   } else {
@@ -154,7 +155,7 @@ space [ \t]
       yy.error(yylloc, 'TLDR104');
     }
     // Check if any sneaky spaces have been caught
-    if (this.matches[3] !== '') yy.error(yylloc, 'TLDR014');
+    this.checkTrailingWhitespace(this.matches[3], yylloc);
     this.checkNewline(this.matches[3], yylloc);
     return 'EXAMPLE_DESCRIPTION';
   } else {


### PR DESCRIPTION
`TLDR014` states that "Page should contain no trailing whitespace", however this was not validated for the title block or the information link lines. 

Adding this rule causes the following pages to error, with included PR resolving the lint:
* [pages/linux/flameshot.md](https://github.com/tldr-pages/tldr/blob/b5a3c99e17fb4ac281f0b15b8757e2ea2a6bba5b/pages/linux/flameshot.md) (https://github.com/tldr-pages/tldr/pull/5068)
* [pages/common/uvicorn.md](https://github.com/tldr-pages/tldr/blob/22577ba81099330d55a19d207d2097d6fa778c06/pages/common/uvicorn.md) (https://github.com/tldr-pages/tldr/pull/5069)