### PR TITLE
fix: allow page titles with + symbol

### DIFF
--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -700,7 +700,7 @@ break;
 case 7:
   if (this.topState() === "title") {
     yy_.yytext = this.matches[1];
-    if (this.matches[1].match(/([^A-Za-z0-9_\. -])|(\.$)/)) yy.error(yy_.yylloc, 'TLDR013');
+    if (this.matches[1].match(/([^A-Za-z0-9_\+\. -])|(\.$)/)) yy.error(yy_.yylloc, 'TLDR013');
     this.checkTrailingWhitespace(this.matches[2], yy_.yylloc);
     this.checkNewline(this.matches[3], yy_.yylloc);
     this.popState();

--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -700,7 +700,7 @@ break;
 case 7:
   if (this.topState() === "title") {
     yy_.yytext = this.matches[1];
-    if (this.matches[1].match(/([^A-Za-z0-9_\+\. -])|(\.$)/)) yy.error(yy_.yylloc, 'TLDR013');
+    if (this.matches[1].match(/([^A-Za-z0-9_+. -])|(\.$)/)) yy.error(yy_.yylloc, 'TLDR013');
     this.checkTrailingWhitespace(this.matches[2], yy_.yylloc);
     this.checkNewline(this.matches[3], yy_.yylloc);
     this.popState();

--- a/specs/pages/title++.md
+++ b/specs/pages/title++.md
@@ -1,0 +1,21 @@
+# title++
+
+> Compiles C++ source files.
+> Part of GCC (GNU Compiler Collection).
+> More information: <https://gcc.gnu.org>.
+
+- Compile a source code file into an executable binary:
+
+`g++ {{source.cpp}} -o {{output_executable}}`
+
+- Display (almost) all errors and warnings:
+
+`g++ {{source.cpp}} -Wall -o {{output_executable}}`
+
+- Choose a language standard to compile for(C++98/C++11/C++14/C++17):
+
+`g++ {{source.cpp}} -std={{language_standard}} -o {{output_executable}}`
+
+- Include libraries located at a different path than the source file:
+
+`g++ {{source.cpp}} -o {{output_executable}} -I{{header_path}} -L{{library_path}} -l{{library_name}}`

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -158,4 +158,9 @@ describe("TLDR pages that are simply correct", function() {
     var errors = lintFile('pages/bracket.md').errors;
     expect(errors.length).toBe(0);
   });
+
+  it("Page filename and title includes + symbol", function() {
+    var errors = lintFile('pages/title++.md').errors;
+    expect(errors.length).toBe(0);
+  });
 });

--- a/tldr.l
+++ b/tldr.l
@@ -99,7 +99,7 @@ space [ \t]
 %{
   if (this.topState() === "title") {
     yytext = this.matches[1];
-    if (this.matches[1].match(/([^A-Za-z0-9_\+\. -])|(\.$)/)) yy.error(yylloc, 'TLDR013');
+    if (this.matches[1].match(/([^A-Za-z0-9_+. -])|(\.$)/)) yy.error(yylloc, 'TLDR013');
     this.checkTrailingWhitespace(this.matches[2], yylloc);
     this.checkNewline(this.matches[3], yylloc);
     this.popState();

--- a/tldr.l
+++ b/tldr.l
@@ -99,7 +99,7 @@ space [ \t]
 %{
   if (this.topState() === "title") {
     yytext = this.matches[1];
-    if (this.matches[1].match(/([^A-Za-z0-9_\. -])|(\.$)/)) yy.error(yylloc, 'TLDR013');
+    if (this.matches[1].match(/([^A-Za-z0-9_\+\. -])|(\.$)/)) yy.error(yylloc, 'TLDR013');
     this.checkTrailingWhitespace(this.matches[2], yylloc);
     this.checkNewline(this.matches[3], yylloc);
     this.popState();


### PR DESCRIPTION
This PR allows for page titles to have the `+` symbol in them. This is nominally to fix the lint failure in tldr-pages/tldr#5088, where I could not rename the page title to be `g++` to match its filename.