### PR TITLE
feat: add lint check for .md file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ TLDR103     | Command example is missing its closing backtick
 TLDR104     | Example descriptions should prefer infinitive tense (e.g. write) over present (e.g. writes) or gerund (e.g. writing)
 TLDR105     | There should be only one command per example
 TLDR106     | Page title should start with a hash (`#`)
+TLDR107     | File name should end with .md extension
 
 [npm-url]: https://www.npmjs.com/package/tldr-lint
 [npm-image]: https://img.shields.io/npm/v/tldr-lint.svg

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ TLDR103     | Command example is missing its closing backtick
 TLDR104     | Example descriptions should prefer infinitive tense (e.g. write) over present (e.g. writes) or gerund (e.g. writing)
 TLDR105     | There should be only one command per example
 TLDR106     | Page title should start with a hash (`#`)
-TLDR107     | File name should end with .md extension
+TLDR107     | File name should end with `.md` extension
 
 [npm-url]: https://www.npmjs.com/package/tldr-lint
 [npm-image]: https://img.shields.io/npm/v/tldr-lint.svg

--- a/lib/tldr-lint-cli.js
+++ b/lib/tldr-lint-cli.js
@@ -37,8 +37,7 @@ cli.writeErrors = function(file, linterResult, args) {
 };
 
 cli.processFile = function(file, args) {
-  var page = fs.readFileSync(file, 'utf8');
-  var linterResult = linter.process(page, args.verbose, args.format);
+  var linterResult = linter.processFile(file, args.verbose, args.format);
   cli.writeErrors(file, linterResult, args);
   return linterResult;
 };

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -1,3 +1,5 @@
+var fs = require('fs');
+var path = require('path');
 parser = require('./tldr-parser.js').parser;
 util = require('util');
 
@@ -27,7 +29,8 @@ module.exports.ERRORS = parser.ERRORS = {
   'TLDR103': 'Command example is missing its closing backtick',
   'TLDR104': 'Example descriptions should prefer infinitive tense (e.g. write) over present (e.g. writes) or gerund (e.g. writing)',
   'TLDR105': 'There should be only one command per example',
-  'TLDR106': 'Page title should start with a hash (\'#\')'
+  'TLDR106': 'Page title should start with a hash (\'#\')',
+  'TLDR107': 'File name should end with .md extension',
 };
 
 (function(parser) {
@@ -158,7 +161,7 @@ linter.format = function(parsedPage) {
 linter.process = function(page, verbose, alsoFormat) {
   var success, page, result;
   try {
-    page = linter.parse(page);
+    linter.parse(page);
     success = true;
   } catch(err) {
     console.error(err.toString());
@@ -169,7 +172,6 @@ linter.process = function(page, verbose, alsoFormat) {
     console.log(parser.yy.page.examples.length + " examples");
     console.log(parser.yy.page.informationLink.length + " link(s)");
   }
-  // TODO add error when filename doesn't match page title
 
   result = {
     page: parser.yy.page,
@@ -186,3 +188,12 @@ linter.process = function(page, verbose, alsoFormat) {
 
   return result;
 };
+
+linter.processFile = function(file, verbose, alsoFormat) {
+  var result = linter.process(fs.readFileSync(file, 'utf8'), verbose, alsoFormat);
+  if (path.extname(file) !== '.md') {
+    result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR107', description: this.ERRORS.TLDR107 });
+  }
+
+  return result;
+}

--- a/specs/pages/107
+++ b/specs/pages/107
@@ -1,0 +1,7 @@
+# jar
+
+> JAR (Java Archive) is a package file format.
+
+- Unzip file to the current directory:
+
+`jar -xvf *.jar`

--- a/specs/tldr-lint-helper.js
+++ b/specs/tldr-lint-helper.js
@@ -5,8 +5,7 @@ var path = require('path');
 var page_dir = './pages';
 
 lintFile = function(file) {
-  var page = fs.readFileSync(path.join(__dirname, file), 'utf8');
-  return linter.process(page);
+  return linter.processFile(path.join(__dirname, file));
 };
 
 containsErrors = function(errors, expected) {

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -146,6 +146,12 @@ describe("Common TLDR formatting errors", function() {
     expect(containsOnlyErrors(errors, 'TLDR106')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
+
+  it("TLDR107\t" + linter.ERRORS.TLDR107, function() {
+    var errors = lintFile('pages/107').errors;
+    expect(containsOnlyErrors(errors, 'TLDR107')).toBeTruthy();
+    expect(errors.length).toBe(1);
+  });
 });
 
 describe("TLDR pages that are simply correct", function() {


### PR DESCRIPTION
This splits apart #32 to only include the lint check for the md file extension. Hopefully this part of it is not contentious and can be merged.

Closes #25