### PR TITLE
feat: add lint check for lowercase filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ TLDR105     | There should be only one command per example
 TLDR106     | Page title should start with a hash (`#`)
 TLDR107     | File name should end with `.md` extension
 TLDR108     | File name should not contain whitespace
+TLDR109     | File name should be lowercase
 
 [npm-url]: https://www.npmjs.com/package/tldr-lint
 [npm-image]: https://img.shields.io/npm/v/tldr-lint.svg

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -201,7 +201,7 @@ linter.processFile = function(file, verbose, alsoFormat) {
     result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR108', description: this.ERRORS.TLDR108 });
   }
 
-  if (RegExp(/[A-Z]/).test(path.basename(file))) {
+  if (/[A-Z]/.test(path.basename(file))) {
     result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR109', description: this.ERRORS.TLDR109 });
   }
 

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -32,6 +32,7 @@ module.exports.ERRORS = parser.ERRORS = {
   'TLDR106': 'Page title should start with a hash (\'#\')',
   'TLDR107': 'File name should end with .md extension',
   'TLDR108': 'File name should not contain whitespace',
+  'TLDR109': 'File name should be lowercase',
 };
 
 (function(parser) {
@@ -198,6 +199,10 @@ linter.processFile = function(file, verbose, alsoFormat) {
 
   if (RegExp(/\s/).test(path.basename(file))) {
     result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR108', description: this.ERRORS.TLDR108 });
+  }
+
+  if (RegExp(/[A-Z]/).test(path.basename(file))) {
+    result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR109', description: this.ERRORS.TLDR109 });
   }
 
   return result;

--- a/specs/pages/109A.md
+++ b/specs/pages/109A.md
@@ -1,0 +1,7 @@
+# jar
+
+> JAR (Java Archive) is a package file format.
+
+- Unzip file to the current directory:
+
+`jar -xvf *.jar`

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -158,6 +158,12 @@ describe("Common TLDR formatting errors", function() {
     expect(containsOnlyErrors(errors, 'TLDR108')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
+
+  it("TLDR109\t" + linter.ERRORS.TLDR109, function () {
+    var errors = lintFile('pages/109A.md').errors;
+    expect(containsOnlyErrors(errors, 'TLDR109')).toBeTruthy();
+    expect(errors.length).toBe(1);
+  });
 });
 
 describe("TLDR pages that are simply correct", function() {


### PR DESCRIPTION
With this change, the following pages are showing as needing to be changed (in the main English versions):

```
pages/common/R.md:0: TLDR109 File name should be lowercase
pages/common/theHarvester.md:0: TLDR109 File name should be lowercase
pages/linux/eyeD3.md:0: TLDR109 File name should be lowercase
pages/osx/GetFileInfo.md:0: TLDR109 File name should be lowercase
pages/osx/csshX.md:0: TLDR109 File name should be lowercase
```

Closes https://github.com/tldr-pages/tldr/issues/5085 (kind of...)