### PR TITLE
allow [ character in title

### DIFF
--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -700,7 +700,7 @@ break;
 case 7:
   if (this.topState() === "title") {
     yy_.yytext = this.matches[1];
-    if (this.matches[1].match(/([^\w+. -])|(\.$)/)) yy.error(yy_.yylloc, 'TLDR013');
+    if (this.matches[1].match(/([^\w+\[. -])|(\.$)/)) yy.error(yy_.yylloc, 'TLDR013');
     this.checkTrailingWhitespace(this.matches[2], yy_.yylloc);
     this.checkNewline(this.matches[3], yy_.yylloc);
     this.popState();

--- a/tldr.l
+++ b/tldr.l
@@ -99,7 +99,7 @@ space [ \t]
 %{
   if (this.topState() === "title") {
     yytext = this.matches[1];
-    if (this.matches[1].match(/([^\w+. -])|(\.$)/)) yy.error(yylloc, 'TLDR013');
+    if (this.matches[1].match(/([^\w+\[. -])|(\.$)/)) yy.error(yylloc, 'TLDR013');
     this.checkTrailingWhitespace(this.matches[2], yylloc);
     this.checkNewline(this.matches[3], yylloc);
     this.popState();


### PR DESCRIPTION
In https://github.com/tldr-pages/tldr/pull/5205, a new page for `[` is being added. tldr-lint doesn't like that very much, so this (should) fix the issue.