### PR TITLE
chore: correct line endings in .gitattributes for specs/pages/failing/010.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 * text=auto
 
 # Required for TLDR010 (Only Unix-style line endings allowed)
-specs/pages/failing/010.md text eol=crlf
+specs/pages/failing/010.md binary


### PR DESCRIPTION
Many good reasons, for one, so that developers can work on tldr-lint on Macs.