### PR TITLE
Cleanup trailing whitespace

### DIFF
--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -90,7 +90,7 @@ case 3:
 this.$ = yy.error(this._$, 'TLDR101') || yy.addDescription($$[$0-1]);;
 break;
 case 4:
-this.$ = yy.setTitle($$[$0]) ;
+this.$ = yy.setTitle($$[$0]);
 break;
 case 5:
 this.$ = yy.error(_$[$0], 'TLDR106') || yy.setTitle($$[$0]);
@@ -108,12 +108,12 @@ case 12:
 this.$ = yy.error(this._$, 'TLDR018');
 break;
 case 15:
- 
+
               yy.addExample($$[$0-2], $$[$0]);
               // Just use the description line's location, easy to find
-              if (!$$[$0-3]) 
+              if (!$$[$0-3])
                 yy.error(_$[$0-2], 'TLDR007');
-              if (!$$[$0-1]) 
+              if (!$$[$0-1])
                 yy.error(_$[$0], 'TLDR007');
             
 break;

--- a/tldr.yy
+++ b/tldr.yy
@@ -15,7 +15,7 @@ page      : title NEWLINE info examples
           | title NEWLINE TEXT examples         -> yy.error(@$, 'TLDR101') || yy.addDescription($TEXT);
           ;
 
-title     : HASH TITLE  -> yy.setTitle($TITLE) 
+title     : HASH TITLE  -> yy.setTitle($TITLE)
           | TEXT        -> yy.error(@TEXT, 'TLDR106') || yy.setTitle($TEXT)
           ;
 
@@ -40,17 +40,17 @@ examples  : %empty
           ;
 
 example   : maybe_newline example_description maybe_newline example_commands
-            { 
+            {
               yy.addExample($example_description, $example_commands);
               // Just use the description line's location, easy to find
-              if (!$maybe_newline1) 
+              if (!$maybe_newline1)
                 yy.error(@example_description, 'TLDR007');
-              if (!$maybe_newline2) 
+              if (!$maybe_newline2)
                 yy.error(@example_commands, 'TLDR007');
             }
           ;
 
-maybe_newline   : %empty 
+maybe_newline   : %empty
                 | NEWLINE
                 ;
 


### PR DESCRIPTION
I didn't touch the test pages because some of them have trailing whitespace intentionally to test the linter.﻿
