### PR TITLE
Remove useless 'files' entries from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "pinst": "^2.1.6"
   },
   "files": [
-    "lib/",
-    "specs/",
-    "tldr.l",
-    "tldr.yy"
+    "lib/"
   ]
 }


### PR DESCRIPTION
To omit specs/ and other development files from the built tarball published
to npm