### PR TITLE
fix passing options to cli

### DIFF
--- a/lib/tldr-lint-cli.js
+++ b/lib/tldr-lint-cli.js
@@ -112,7 +112,7 @@ if (require.main === module) {
     .parse(process.argv);
 
   if (program.args.length !== 1) {
-    program.help();
+    program.help({ error: true });
   }
   cli.process(program.args[0], program.opts());
   process.exit(0);

--- a/lib/tldr-lint-cli.js
+++ b/lib/tldr-lint-cli.js
@@ -73,15 +73,11 @@ cli.processDirectory = function(dir, args) {
   return result;
 };
 
-cli.process = function(args) {
-  if (args.args.length != 1) {
-    args.help();
-  }
+cli.process = function(file, args) {
   if (args.output && !args.format) {
     console.error('--output only makes sense when used with --format');
     process.exit(1);
   }
-  var file = args.args[0];
   try {
     var stats = fs.statSync(file);
   } catch(err) {
@@ -102,9 +98,9 @@ cli.process = function(args) {
 };
 
 if (require.main === module) {
-  var args = require('commander');
+  var program = require('commander');
   var package = require('../package.json');
-  args
+  program
     .version(package.version)
     .description(package.description)
     .arguments('<file|dir>')
@@ -115,6 +111,9 @@ if (require.main === module) {
     .option('-v, --verbose', 'print verbose output')
     .parse(process.argv);
 
-  cli.process(args);
+  if (program.args.length !== 1) {
+    program.help();
+  }
+  cli.process(program.args[0], program.opts());
   process.exit(0);
 }


### PR DESCRIPTION
Upgrading to commander 7 (6a2adb2a4bfc07c2f4a24d0340fe76089bc27c31) had a couple of breaking changes with how commander is used, and the args and options referenced. This meant that trying to pass in the `--verbose` flag was broken for example. This PR updates the codebase so that it utilizes the new commander output structure.

Given that the parameter passed to `cli.process` different due to breaking change when going to commander 7, I decided to then modify the parameter list to have it be a bit more straight forward such that it no longer relies on commander per-se, but rather just accepts a string filename and a key/value object of arguments.