### PR TITLE
run eslint over specs directory

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -4,7 +4,6 @@
         "**/*.spec.js"
     ],
     "helpers": [
-        "tldr-lint-helper.js"
     ],
     "stopSpecOnExpectationFailure": false,
     "random": false

--- a/jasmine.json
+++ b/jasmine.json
@@ -3,8 +3,6 @@
     "spec_files": [
         "**/*.spec.js"
     ],
-    "helpers": [
-    ],
     "stopSpecOnExpectationFailure": false,
     "random": false
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "tldr-pages/tldr-lint",
   "scripts": {
     "jison": "jison tldr.yy tldr.l -o lib/tldr-parser.js",
-    "lint": "eslint lib",
+    "lint": "eslint lib specs",
     "prepublishOnly": "pinst --disable",
     "postinstall": "husky install",
     "postpublish": "pinst --enable",

--- a/specs/.eslintrc.json
+++ b/specs/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "env": {
+        "jasmine": true
+    }
+}

--- a/specs/tldr-lint-helper.js
+++ b/specs/tldr-lint-helper.js
@@ -1,43 +1,46 @@
 var linter = require('../lib/tldr-lint.js');
-var fs = require('fs');
 var path = require('path');
 
-var page_dir = './pages';
-
-lintFile = function(file) {
+var lintFile = function(file) {
   return linter.processFile(path.join(__dirname, file));
 };
 
-containsErrors = function(errors, expected) {
+var containsErrors = function(errors, expected) {
   if (errors.length === 0) return false;
   if (!(expected instanceof Array))
     expected = Array.prototype.splice.call(arguments, 1);
   expected.forEach(function(expectedCode) {
     // If not some correspond to every expected, false
-    if (!errors.some(function(error) { error === expectedCode; }))
+    if (!errors.some(function(error) { return error === expectedCode; }))
       return false;
   });
   return true;
 };
 
-containsOnlyErrors = function(errors, expected) {
+var containsOnlyErrors = function(errors, expected) {
   if (!(expected instanceof Array)) {
     expected = Array.prototype.splice.call(arguments, 1);
   }
   expected.forEach(function(error) {
     if (!containsErrors(errors, error)) {
-      console.error('Couldnt find error', error, 'in these errors')
-      console.error(errors)
+      console.error('Couldnt find error', error, 'in these errors');
+      console.error(errors);
       return false;
-    };
+    }
   });
-  for (var i = 0, error; i < errors.length; i++) {
+  for (var i = 0; i < errors.length; i++) {
     var error = errors[i];
     if (!expected.some(function(expectedCode) {
       return error.code === expectedCode;
     })) {
       return false;
     }
-  };
+  }
   return true;
+};
+
+module.exports = {
+  lintFile,
+  containsErrors,
+  containsOnlyErrors,
 };

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -1,183 +1,186 @@
-var linter = require('../lib/tldr-lint.js');
+/* eslint-disable no-magic-numbers */
 
-describe("TLDR conventions", function() {
-  it("TLDR001\t" + linter.ERRORS.TLDR001, function() {
+var linter = require('../lib/tldr-lint.js');
+var { lintFile, containsErrors, containsOnlyErrors } = require('./tldr-lint-helper');
+
+describe('TLDR conventions', function() {
+  it('TLDR001\t' + linter.ERRORS.TLDR001, function() {
     var errors = lintFile('pages/failing/001.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR001')).toBeTruthy();
   });
 
-  it("TLDR002\t" + linter.ERRORS.TLDR002, function() {
+  it('TLDR002\t' + linter.ERRORS.TLDR002, function() {
     var errors = lintFile('pages/failing/002.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR002')).toBeTruthy();
     // This error should occur in 3 different places
     expect(errors.length).toBe(3);
   });
 
-  it("TLDR003\t" + linter.ERRORS.TLDR003, function() {
+  it('TLDR003\t' + linter.ERRORS.TLDR003, function() {
     var errors = lintFile('pages/failing/003.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR003')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR004\t" + linter.ERRORS.TLDR004, function() {
+  it('TLDR004\t' + linter.ERRORS.TLDR004, function() {
     var errors = lintFile('pages/failing/004.md').errors;
     expect(containsErrors(errors, ['TLDR004', 'TLDR014'])).toBeTruthy();
     expect(errors.length).toBe(4);
   });
 
-  it("TLDR005\t" + linter.ERRORS.TLDR005, function() {
+  it('TLDR005\t' + linter.ERRORS.TLDR005, function() {
     var errors = lintFile('pages/failing/005.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR005')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
-  it("TLDR006\t" + linter.ERRORS.TLDR006, function() {
+  it('TLDR006\t' + linter.ERRORS.TLDR006, function() {
     var errors = lintFile('pages/failing/006.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR006')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR007\t" + linter.ERRORS.TLDR007, function() {
+  it('TLDR007\t' + linter.ERRORS.TLDR007, function() {
     var errors = lintFile('pages/failing/007.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR007')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
-  it("TLDR008\t" + linter.ERRORS.TLDR008, function() {
+  it('TLDR008\t' + linter.ERRORS.TLDR008, function() {
     var errors = lintFile('pages/failing/008.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR008')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR009\t" + linter.ERRORS.TLDR009, function() {
+  it('TLDR009\t' + linter.ERRORS.TLDR009, function() {
     var errors = lintFile('pages/failing/009.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR009')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR011\t" + linter.ERRORS.TLDR011, function() {
+  it('TLDR011\t' + linter.ERRORS.TLDR011, function() {
     var errors = lintFile('pages/failing/011.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR011')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
-  it("TLDR012\t" + linter.ERRORS.TLDR012, function() {
+  it('TLDR012\t' + linter.ERRORS.TLDR012, function() {
     var errors = lintFile('pages/failing/012.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR012')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
-  it("TLDR013\t" + linter.ERRORS.TLDR013, function() {
+  it('TLDR013\t' + linter.ERRORS.TLDR013, function() {
     var errors = lintFile('pages/failing/013.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR013')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR014\t" + linter.ERRORS.TLDR014, function() {
+  it('TLDR014\t' + linter.ERRORS.TLDR014, function() {
     var errors = lintFile('pages/failing/014.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR014')).toBeTruthy();
     expect(errors.length).toBe(5);
   });
 
-  it("TLDR015\t" + linter.ERRORS.TLDR015, function() {
+  it('TLDR015\t' + linter.ERRORS.TLDR015, function() {
     var errors = lintFile('pages/failing/015.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR015')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR016\t" + linter.ERRORS.TLDR016, function() {
+  it('TLDR016\t' + linter.ERRORS.TLDR016, function() {
     var errors = lintFile('pages/failing/016.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR016')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR017\t" + linter.ERRORS.TLDR017, function() {
+  it('TLDR017\t' + linter.ERRORS.TLDR017, function() {
     var errors = lintFile('pages/failing/017.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR017')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR018\t" + linter.ERRORS.TLDR018, function() {
+  it('TLDR018\t' + linter.ERRORS.TLDR018, function() {
     var errors = lintFile('pages/failing/018.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR018')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
-  it("TLDR019\t" + linter.ERRORS.TLDR019, function() {
+  it('TLDR019\t' + linter.ERRORS.TLDR019, function() {
     var errors = lintFile('pages/failing/019.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR019')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 });
 
-describe("Common TLDR formatting errors", function() {
-  it("TLDR101\t" + linter.ERRORS.TLDR101, function() {
+describe('Common TLDR formatting errors', function() {
+  it('TLDR101\t' + linter.ERRORS.TLDR101, function() {
     var errors = lintFile('pages/failing/101.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR101')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR102\t" + linter.ERRORS.TLDR102, function() {
+  it('TLDR102\t' + linter.ERRORS.TLDR102, function() {
     var errors = lintFile('pages/failing/102.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR102')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR103\t" + linter.ERRORS.TLDR103, function() {
+  it('TLDR103\t' + linter.ERRORS.TLDR103, function() {
     var errors = lintFile('pages/failing/103.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR103')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
-  it("TLDR104\t" + linter.ERRORS.TLDR104, function() {
+  it('TLDR104\t' + linter.ERRORS.TLDR104, function() {
     var errors = lintFile('pages/failing/104.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR104')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
-  it("TLDR105\t" + linter.ERRORS.TLDR105, function() {
+  it('TLDR105\t' + linter.ERRORS.TLDR105, function() {
     var errors = lintFile('pages/failing/105.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR105')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
-  it("TLDR106\t" + linter.ERRORS.TLDR106, function() {
+  it('TLDR106\t' + linter.ERRORS.TLDR106, function() {
     var errors = lintFile('pages/failing/106.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR106')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR107\t" + linter.ERRORS.TLDR107, function() {
+  it('TLDR107\t' + linter.ERRORS.TLDR107, function() {
     var errors = lintFile('pages/failing/107').errors;
     expect(containsOnlyErrors(errors, 'TLDR107')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR108\t" + linter.ERRORS.TLDR108, function () {
+  it('TLDR108\t' + linter.ERRORS.TLDR108, function () {
     var errors = lintFile('pages/failing/108 .md').errors;
     expect(containsOnlyErrors(errors, 'TLDR108')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
-  it("TLDR109\t" + linter.ERRORS.TLDR109, function () {
+  it('TLDR109\t' + linter.ERRORS.TLDR109, function () {
     var errors = lintFile('pages/failing/109A.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR109')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 });
 
-describe("TLDR pages that are simply correct", function() {
-  it("Multiple description lines", function() {
+describe('TLDR pages that are simply correct', function() {
+  it('Multiple description lines', function() {
     var errors = lintFile('pages/passing/descriptions.md').errors;
     expect(errors.length).toBe(0);
   });
 
-  it("Example starting with a bracket", function() {
+  it('Example starting with a bracket', function() {
     var errors = lintFile('pages/passing/bracket.md').errors;
     expect(errors.length).toBe(0);
   });
 
-  it("Page filename and title includes + symbol", function() {
+  it('Page filename and title includes + symbol', function() {
     var errors = lintFile('pages/passing/title++.md').errors;
     expect(errors.length).toBe(0);
   });


### PR DESCRIPTION
The specs directory was not being linted, This was causing my editor to be upset when I opened a test file. This PR changes it so that it will be.

Beyond the lint changes, the most significant change is removing the `specs/tldr-lint-helper.js` file from jasmine helper to being just a regularly imported module. It's not super well documented, but the `helpers` of jasmine is aimed at allowing developers to augment the built-in jasmine behavior or run `beforeEach` methods for test suite or whatever, not really setting custom util functions. You can use it for that, but then it requires specifying that each is a global variable for eslint to work and also abusing JS hoisting to even function (e.g. you have to write `lintFile = function(file)`, writing `var lintFile = function(file)` will cause the test suite to not work) which is dumb and not intuitive. Much easier and better (imo) to have it be a regular old import within the test suite.