### PR TITLE
add flag to ignore specific errors

### DIFF
--- a/lib/tldr-lint-cli.js
+++ b/lib/tldr-lint-cli.js
@@ -38,7 +38,7 @@ cli.writeErrors = function(file, linterResult, args) {
 };
 
 cli.processFile = function(file, args) {
-  var linterResult = linter.processFile(file, args.verbose, args.format);
+  var linterResult = linter.processFile(file, args.verbose, args.format, args.ignore);
   cli.writeErrors(file, linterResult, args);
   return linterResult;
 };
@@ -109,6 +109,7 @@ if (require.main === module) {
     .option('-i, --in-place', 'formats in place')
     .option('-t, --tabular', 'format errors in a tabular format')
     .option('-v, --verbose', 'print verbose output')
+    .option('-i, --ignore <codes>', 'ignore comma separated tldr-lint error codes (e.g. "TLDR001,TLDR0014")')
     .parse(process.argv);
 
   if (program.args.length !== 1) {

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -194,7 +194,7 @@ linter.process = function(file, page, verbose, alsoFormat) {
   return result;
 };
 
-linter.processFile = function(file, verbose, alsoFormat) {
+linter.processFile = function(file, verbose, alsoFormat, ignoreErrors) {
   var result = linter.process(file, fs.readFileSync(file, 'utf8'), verbose, alsoFormat);
   if (path.extname(file) !== '.md') {
     result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR107', description: this.ERRORS.TLDR107 });
@@ -206,6 +206,15 @@ linter.processFile = function(file, verbose, alsoFormat) {
 
   if (/[A-Z]/.test(path.basename(file))) {
     result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR109', description: this.ERRORS.TLDR109 });
+  }
+
+  if (ignoreErrors) {
+    ignoreErrors = ignoreErrors.split(',').map(function(val) {
+      return val.trim();
+    });
+    result.errors = result.errors.filter(function(error) {
+      return !ignoreErrors.includes(error.code);
+    });
   }
 
   return result;

--- a/specs/tldr-lint-helper.js
+++ b/specs/tldr-lint-helper.js
@@ -1,8 +1,8 @@
 var linter = require('../lib/tldr-lint.js');
 var path = require('path');
 
-var lintFile = function(file) {
-  return linter.processFile(path.join(__dirname, file));
+var lintFile = function(file, ignoreErrors) {
+  return linter.processFile(path.join(__dirname, file), false, false, ignoreErrors);
 };
 
 var containsErrors = function(errors, expected) {

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -185,3 +185,11 @@ describe('TLDR pages that are simply correct', function() {
     expect(errors.length).toBe(0);
   });
 });
+
+describe('ignore errors', function() {
+  it('ignore TLDR014', function() {
+    var errors = lintFile('pages/failing/004.md', 'TLDR014').errors;
+    expect(containsOnlyErrors(errors, 'TLDR004')).toBeTruthy();
+    expect(errors.length).toBe(2);
+  });
+});


### PR DESCRIPTION
This adds a new flag to allow ignoring specific TLDR errors (comma separated). The purpose here is to then hook up tldr-lint to run on all incoming pages (not just english) and comment as appropriate, ignoring the rules that are english only.