### PR TITLE
move husky to prepare run-script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "version": "0.0.10",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^7.0.0"
@@ -22,8 +21,7 @@
         "jasmine": "^3.6.4",
         "jasmine-console-reporter": "^3.1.0",
         "jison": "^0.4.18",
-        "onchange": "^7.1.0",
-        "pinst": "^2.1.6"
+        "onchange": "^7.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1064,12 +1062,6 @@
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
-    "node_modules/fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1744,21 +1736,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "dependencies": {
-        "fromentries": "^1.3.2"
-      },
-      "bin": {
-        "pinst": "bin.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -3203,12 +3180,6 @@
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3749,15 +3720,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
-    },
-    "pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.3.2"
-      }
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "scripts": {
     "jison": "jison tldr.yy tldr.l -o lib/tldr-parser.js",
     "lint": "eslint lib specs",
-    "prepublishOnly": "pinst --disable",
-    "postinstall": "husky install",
-    "postpublish": "pinst --enable",
+    "prepare": "husky install",
     "test": "jasmine --config=jasmine.json --reporter=jasmine-console-reporter",
     "watch": "concurrently 'npm run watch:jison' 'npm run watch:specs'",
     "watch:jison": "onchange '*.l' '*.yy' -- npm run jison",
@@ -40,8 +38,7 @@
     "jasmine": "^3.6.4",
     "jasmine-console-reporter": "^3.1.0",
     "jison": "^0.4.18",
-    "onchange": "^7.1.0",
-    "pinst": "^2.1.6"
+    "onchange": "^7.1.0"
   },
   "files": [
     "lib/"


### PR DESCRIPTION
This moves husky to be run as the recommended `prepare` run-script instead of `postinstall` and `prepublish` stuff it did have. This has the advantage that prepare will run only on installing and publishing in the local directory, and not affect any downstream installations of the linter, rendering the `pinst` devDependency redundant and unnecessary.