### PR TITLE
chore: release v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 - Add CLI flag to ignore specific errors ([#69](https://github.com/tldr-pages/tldr-lint/pull/69))
 
 ### Changed
+- Allow words at the beginning of descriptions to end with "ys" ([#60](https://github.com/tldr-pages/tldr-lint/pull/60))
 - Print out filename above parse errors ([#62](https://github.com/tldr-pages/tldr-lint/pull/62))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 - Add CLI flag to ignore specific errors ([#69](https://github.com/tldr-pages/tldr-lint/pull/69))
 
 ### Changed
-- Allow words at the beginning of descriptions to end with "ys" ([#60](https://github.com/tldr-pages/tldr-lint/pull/60))
+- Allow words at the beginning of example descriptions to end with "ys" ([#60](https://github.com/tldr-pages/tldr-lint/pull/60))
 - Print out filename above parse errors ([#62](https://github.com/tldr-pages/tldr-lint/pull/62))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## [v0.0.11 - 2021-04-14](https://github.com/tldr-pages/tldr-lint/compare/v0.0.10...v0.0.11)
+
+### Added
+- Add CLI flag to ignore specific errors ([#69](https://github.com/tldr-pages/tldr-lint/pull/69))
+
+### Changed
+- Print out filename above parse errors ([#62](https://github.com/tldr-pages/tldr-lint/pull/62))
+
+### Fixed
+- Fix passing options to CLI ([#59](https://github.com/tldr-pages/tldr-lint/pull/59))
+
 ## [v0.0.10 - 2021-03-01](https://github.com/tldr-pages/tldr-lint/compare/v0.0.9...v0.0.10)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tldr-lint",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldr-lint",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A linting tool to validate tldr pages",
   "repository": "tldr-pages/tldr-lint",
   "scripts": {


### PR DESCRIPTION
Bumping the version of tldr-lint here as I'd like to incorporate the changes here into the general tldr repo, especially running most of tldr-lint over all non-english pages with the exception of a handful of the rules that are English oriented (e.g. TLDR104).

I think that this could be merged after #60 which is ready sans test case, as not sure there's any user facing changes in the immediate works that would want to be included into this release.