### PR TITLE
chore: allow special uppercased characters

### DIFF
--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -747,7 +747,7 @@ case 9:
   if (this.topState() === 'example_description') {
     this.popState();
     yy_.yytext = this.matches[1];
-    if (!yy_.yytext.match(/^[A-Z[]/)) yy.error(yy_.yylloc, 'TLDR015');
+    if (!yy_.yytext.match(/^[\p{Lu}\[]/u)) yy.error(yy_.yylloc, 'TLDR015');
     if (this.matches[2] !== ':') yy.error(yy_.yylloc, 'TLDR005');
     // Try to ensure that verbs at the beginning of the description are in the infinitive tense
     // 1. Any word at the start of a sentence that ends with "ing" and is 6 or more characters long (e.g. executing, writing) is likely a verb in the gerund

--- a/specs/pages/passing/special-characters.md
+++ b/specs/pages/passing/special-characters.md
@@ -1,0 +1,9 @@
+# command
+
+> Test for special upercased characters.
+> For exemple french has this upercased letters `Ê`, `À`, `Ė`, `Ç` etc ..
+> More information: <https://stackoverflow.com/a/4052294/7149816>.
+
+- Éxecute une commande (exec a cmd in french):
+
+`command`

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -180,6 +180,11 @@ describe('TLDR pages that are simply correct', function() {
     expect(errors.length).toBe(0);
   });
 
+  it('Example starting with an upper cased unicode character', function() {
+    var errors = lintFile('pages/passing/special-characters.md').errors;
+    expect(errors.length).toBe(0);
+  });
+
   it('Page filename and title includes + symbol', function() {
     var errors = lintFile('pages/passing/title++.md').errors;
     expect(errors.length).toBe(0);

--- a/tldr.l
+++ b/tldr.l
@@ -149,7 +149,7 @@ space [ \t]
   if (this.topState() === 'example_description') {
     this.popState();
     yytext = this.matches[1];
-    if (!yytext.match(/^[A-Z[]/)) yy.error(yylloc, 'TLDR015');
+    if (!yytext.match(/^[\p{Lu}\[]/u)) yy.error(yylloc, 'TLDR015');
     if (this.matches[2] !== ':') yy.error(yylloc, 'TLDR005');
     // Try to ensure that verbs at the beginning of the description are in the infinitive tense
     // 1. Any word at the start of a sentence that ends with "ing" and is 6 or more characters long (e.g. executing, writing) is likely a verb in the gerund


### PR DESCRIPTION
## Problem

Many latin language (in my case french) have an issue with the rule `TLDR015` => `Example descriptions should start with a capital letter`

If i want to start my sentence with a `È` it's not possible because the actual regex is => `/^[A-Z[]/`

## Solution

Using this regex `/^[\p{Lu}\[]/u` instead do the trick

I also added a unit test for this case :) 