### PR TITLE
Allow exceptions to TLDR003

### DIFF
--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -725,7 +725,8 @@ case 8:
   if (this.topState() === 'description') {
     this.popState();
     yy_.yytext = this.matches[1];
-    if (yy_.yytext.match(/^[a-z]/)) {
+    var exceptions = ['npm', 'pnpm'];
+    if (!exceptions.includes(yy_.yytext.replace(/ .*/,'')) && yy_.yytext.match(/^[a-z]/)) {
       yy.error(yy_.yylloc, 'TLDR003');
     }
     var punctuation = this.matches[2];

--- a/specs/pages/passing/lower-case.md
+++ b/specs/pages/passing/lower-case.md
@@ -1,0 +1,4 @@
+# npm
+
+> npm is always written in lower case.
+> This just goes on.

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -189,6 +189,11 @@ describe('TLDR pages that are simply correct', function() {
     var errors = lintFile('pages/passing/title++.md').errors;
     expect(errors.length).toBe(0);
   });
+
+  it('Certain words are always written in lower case', function() {
+    var errors = lintFile('pages/passing/lower-case.md').errors;
+    expect(errors.length).toBe(0);
+  });
 });
 
 describe('ignore errors', function() {

--- a/tldr.l
+++ b/tldr.l
@@ -125,7 +125,8 @@ space [ \t]
   if (this.topState() === 'description') {
     this.popState();
     yytext = this.matches[1];
-    if (yytext.match(/^[a-z]/)) {
+    var exceptions = ['npm', 'pnpm'];
+    if (!exceptions.includes(yytext.replace(/ .*/,'')) && yytext.match(/^[a-z]/)) {
       yy.error(yylloc, 'TLDR003');
     }
     var punctuation = this.matches[2];


### PR DESCRIPTION
A small update to the `TLDR003` rule to allow certain words which are **always** written in lower case (e.g. [`npm`](https://www.npmjs.com/)).

This is related to: https://github.com/tldr-pages/tldr/pull/6825