### PR TITLE
CI: upgrade version of actions/setup-node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,19 +26,11 @@ jobs:
         
     - uses: actions/checkout@v2
 
-    - name: Cache node modules
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ matrix.os }}-${{ matrix.node-version }}-npm-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ matrix.os }}-${{ matrix.node-version }}-npm-
-          ${{ matrix.os }}-npm-
-
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+        cache: npm
 
     - run: npm ci
     - run: npm run lint


### PR DESCRIPTION
This PR upgrades the version of `actions/setup-node` to `v2`, which includes builtin support for caching, allowing us to simplify the workflow a bit.