### PR TITLE
Set Node 12 as minimum supported version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches: [ '*' ]
-  pull_request:
-    branches: [ '*' ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -13,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # todo: windows-latest
-        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
 
     name: Node ${{ matrix.node-version }} - ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "name": "Ruben Vereecken",
     "email": "rubenvereecken@gmail.com"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "license": "MIT",
   "dependencies": {
     "commander": "^8.1.0"


### PR DESCRIPTION
Per discussion in #106, this sets the minimum supported version of tldr-lint to Node 12.