### PR TITLE
Replace testing on 15.x with 17.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # todo: windows-latest
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
 
     name: Node ${{ matrix.node-version }} - ${{ matrix.os }}
 


### PR DESCRIPTION
Node 15.x is EOL, and the 17.x release line is the current non-LTS supported version.