### PR TITLE
Replace usage of var with const/let

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
       "ignoreArrayIndexes": true,
       "detectObjects": true
     }],
+    "no-var": "error",
     "no-warning-comments": "warn",
     "handle-callback-err": "error"
   },

--- a/lib/tldr-lint-cli.js
+++ b/lib/tldr-lint-cli.js
@@ -1,18 +1,13 @@
 #!/usr/bin/env node
 
-var linter = require('./tldr-lint.js');
-var fs = require('fs');
-var path = require('path');
-var cli = module.exports;
-var util = require('util');
+const linter = require('./tldr-lint.js');
+const fs = require('fs');
+const path = require('path');
+const cli = module.exports;
+const util = require('util');
 
 cli.writeErrors = function(file, linterResult, args) {
-  var format;
-  if (args.tabular) {
-    format = '%s\t%s\t%s\t%s\t';
-  } else {
-    format = '%s:%s: %s %s';
-  }
+  const format = args.tabular ? '%s\t%s\t%s\t%s\t' : '%s:%s: %s %s';
   linterResult.errors.forEach(function(error) {
     console.error(util.format(format, file, (error.locinfo.first_line ||
                                             error.locinfo.last_line - 1),
@@ -22,8 +17,8 @@ cli.writeErrors = function(file, linterResult, args) {
     if (!linterResult.success) {
       console.error('Refraining from formatting because of fatal error');
     } else {
-      var formattedPage = linterResult.formatted;
-      var err;
+      const formattedPage = linterResult.formatted;
+      let err;
       if (args.output) {
         err = fs.writeFileSync(args.output, formattedPage, 'utf8');
         if (err) throw err;
@@ -38,15 +33,15 @@ cli.writeErrors = function(file, linterResult, args) {
 };
 
 cli.processFile = function(file, args) {
-  var linterResult = linter.processFile(file, args.verbose, args.format, args.ignore);
+  const linterResult = linter.processFile(file, args.verbose, args.format, args.ignore);
   cli.writeErrors(file, linterResult, args);
   return linterResult;
 };
 
 cli.processDirectory = function(dir, args) {
-  var files = fs.readdirSync(dir);
-  var stats;
-  var result = {
+  const files = fs.readdirSync(dir);
+  let stats;
+  const result = {
     success: true,
     errors: []
   };
@@ -61,11 +56,11 @@ cli.processDirectory = function(dir, args) {
     if (stats.isFile()) {
       // Only treat files ending in .md
       if (!file.match(/\.md$/)) return;
-      var linterResult = cli.processFile(file, args);
+      const linterResult = cli.processFile(file, args);
       result.success &= linterResult.success;
       result.errors = result.errors.concat(linterResult.errors);
     } else {
-      var aggregateResult = cli.processDirectory(file, args);
+      const aggregateResult = cli.processDirectory(file, args);
       result.success &= aggregateResult.success;
       result.errors = result.errors.concat(aggregateResult.errors);
     }
@@ -78,28 +73,24 @@ cli.process = function(file, args) {
     console.error('--output only makes sense when used with --format');
     process.exit(1);
   }
+  let stats;
   try {
-    var stats = fs.statSync(file);
+    stats = fs.statSync(file);
   } catch(err) {
     console.error(err.toString());
     process.exit(1);
   }
-  var isdir = stats.isDirectory();
+  const isdir = stats.isDirectory();
   if (args.output && isdir) {
     console.error('--output only makes sense when used with a file');
   }
-  var result;
-  if (!isdir) {
-    result = cli.processFile(file, args);
-  } else {
-    result = cli.processDirectory(file, args);
-  }
+  const result = isdir ? cli.processDirectory(file, args) : cli.processFile(file, args);
   if (!result.success || result.errors.length >= 1) return process.exit(1);
 };
 
 if (require.main === module) {
-  var program = require('commander');
-  var package = require('../package.json');
+  const program = require('commander');
+  const package = require('../package.json');
   program
     .version(package.version)
     .description(package.description)

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -1,7 +1,7 @@
-var fs = require('fs');
-var path = require('path');
-var parser = require('./tldr-parser.js').parser;
-var util = require('util');
+const fs = require('fs');
+const path = require('path');
+const parser = require('./tldr-parser.js').parser;
+const util = require('util');
 
 const MAX_EXAMPLES = 8;
 
@@ -117,7 +117,7 @@ module.exports.ERRORS = parser.ERRORS = {
   };
 })(parser);
 
-var linter = module.exports;
+const linter = module.exports;
 
 linter.parse = function(page) {
   parser.init();
@@ -135,7 +135,7 @@ linter.formatExampleDescription = function(str) {
 };
 
 linter.format = function(parsedPage) {
-  var str = '';
+  let str = '';
   str += util.format('# %s', parsedPage.title);
   str += '\n\n';
   parsedPage.description.forEach(function(line) {
@@ -163,7 +163,7 @@ linter.format = function(parsedPage) {
 };
 
 linter.process = function(file, page, verbose, alsoFormat) {
-  var success, result;
+  let success, result;
   try {
     linter.parse(page);
     success = true;
@@ -195,7 +195,7 @@ linter.process = function(file, page, verbose, alsoFormat) {
 };
 
 linter.processFile = function(file, verbose, alsoFormat, ignoreErrors) {
-  var result = linter.process(file, fs.readFileSync(file, 'utf8'), verbose, alsoFormat);
+  const result = linter.process(file, fs.readFileSync(file, 'utf8'), verbose, alsoFormat);
   if (path.extname(file) !== '.md') {
     result.errors.push({ locinfo: { first_line: '0' }, code: 'TLDR107', description: this.ERRORS.TLDR107 });
   }

--- a/specs/tldr-lint-helper.js
+++ b/specs/tldr-lint-helper.js
@@ -1,11 +1,11 @@
-var linter = require('../lib/tldr-lint.js');
-var path = require('path');
+const linter = require('../lib/tldr-lint.js');
+const path = require('path');
 
-var lintFile = function(file, ignoreErrors) {
+const lintFile = function(file, ignoreErrors) {
   return linter.processFile(path.join(__dirname, file), false, false, ignoreErrors);
 };
 
-var containsErrors = function(errors, expected) {
+const containsErrors = function(errors, expected) {
   if (errors.length === 0) return false;
   if (!(expected instanceof Array))
     expected = Array.prototype.splice.call(arguments, 1);
@@ -17,7 +17,7 @@ var containsErrors = function(errors, expected) {
   return true;
 };
 
-var containsOnlyErrors = function(errors, expected) {
+const containsOnlyErrors = function(errors, expected) {
   if (!(expected instanceof Array)) {
     expected = Array.prototype.splice.call(arguments, 1);
   }
@@ -28,8 +28,8 @@ var containsOnlyErrors = function(errors, expected) {
       return false;
     }
   });
-  for (var i = 0; i < errors.length; i++) {
-    var error = errors[i];
+  for (let i = 0; i < errors.length; i++) {
+    const error = errors[i];
     if (!expected.some(function(expectedCode) {
       return error.code === expectedCode;
     })) {

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -1,113 +1,113 @@
 /* eslint-disable no-magic-numbers */
 
-var linter = require('../lib/tldr-lint.js');
-var { lintFile, containsErrors, containsOnlyErrors } = require('./tldr-lint-helper');
+const linter = require('../lib/tldr-lint.js');
+const { lintFile, containsErrors, containsOnlyErrors } = require('./tldr-lint-helper');
 
 describe('TLDR conventions', function() {
   it('TLDR001\t' + linter.ERRORS.TLDR001, function() {
-    var errors = lintFile('pages/failing/001.md').errors;
+    const errors = lintFile('pages/failing/001.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR001')).toBeTruthy();
   });
 
   it('TLDR002\t' + linter.ERRORS.TLDR002, function() {
-    var errors = lintFile('pages/failing/002.md').errors;
+    const errors = lintFile('pages/failing/002.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR002')).toBeTruthy();
     // This error should occur in 3 different places
     expect(errors.length).toBe(3);
   });
 
   it('TLDR003\t' + linter.ERRORS.TLDR003, function() {
-    var errors = lintFile('pages/failing/003.md').errors;
+    const errors = lintFile('pages/failing/003.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR003')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR004\t' + linter.ERRORS.TLDR004, function() {
-    var errors = lintFile('pages/failing/004.md').errors;
+    let errors = lintFile('pages/failing/004.md').errors;
     expect(containsErrors(errors, ['TLDR004', 'TLDR014'])).toBeTruthy();
     expect(errors.length).toBe(4);
   });
 
   it('TLDR005\t' + linter.ERRORS.TLDR005, function() {
-    var errors = lintFile('pages/failing/005.md').errors;
+    let errors = lintFile('pages/failing/005.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR005')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
   it('TLDR006\t' + linter.ERRORS.TLDR006, function() {
-    var errors = lintFile('pages/failing/006.md').errors;
+    let errors = lintFile('pages/failing/006.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR006')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR007\t' + linter.ERRORS.TLDR007, function() {
-    var errors = lintFile('pages/failing/007.md').errors;
+    let errors = lintFile('pages/failing/007.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR007')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
   it('TLDR008\t' + linter.ERRORS.TLDR008, function() {
-    var errors = lintFile('pages/failing/008.md').errors;
+    let errors = lintFile('pages/failing/008.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR008')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR009\t' + linter.ERRORS.TLDR009, function() {
-    var errors = lintFile('pages/failing/009.md').errors;
+    let errors = lintFile('pages/failing/009.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR009')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR011\t' + linter.ERRORS.TLDR011, function() {
-    var errors = lintFile('pages/failing/011.md').errors;
+    let errors = lintFile('pages/failing/011.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR011')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
   it('TLDR012\t' + linter.ERRORS.TLDR012, function() {
-    var errors = lintFile('pages/failing/012.md').errors;
+    let errors = lintFile('pages/failing/012.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR012')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
   it('TLDR013\t' + linter.ERRORS.TLDR013, function() {
-    var errors = lintFile('pages/failing/013.md').errors;
+    let errors = lintFile('pages/failing/013.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR013')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR014\t' + linter.ERRORS.TLDR014, function() {
-    var errors = lintFile('pages/failing/014.md').errors;
+    let errors = lintFile('pages/failing/014.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR014')).toBeTruthy();
     expect(errors.length).toBe(5);
   });
 
   it('TLDR015\t' + linter.ERRORS.TLDR015, function() {
-    var errors = lintFile('pages/failing/015.md').errors;
+    let errors = lintFile('pages/failing/015.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR015')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR016\t' + linter.ERRORS.TLDR016, function() {
-    var errors = lintFile('pages/failing/016.md').errors;
+    let errors = lintFile('pages/failing/016.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR016')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR017\t' + linter.ERRORS.TLDR017, function() {
-    var errors = lintFile('pages/failing/017.md').errors;
+    let errors = lintFile('pages/failing/017.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR017')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR018\t' + linter.ERRORS.TLDR018, function() {
-    var errors = lintFile('pages/failing/018.md').errors;
+    let errors = lintFile('pages/failing/018.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR018')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
   it('TLDR019\t' + linter.ERRORS.TLDR019, function() {
-    var errors = lintFile('pages/failing/019.md').errors;
+    let errors = lintFile('pages/failing/019.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR019')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
@@ -115,55 +115,55 @@ describe('TLDR conventions', function() {
 
 describe('Common TLDR formatting errors', function() {
   it('TLDR101\t' + linter.ERRORS.TLDR101, function() {
-    var errors = lintFile('pages/failing/101.md').errors;
+    let errors = lintFile('pages/failing/101.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR101')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR102\t' + linter.ERRORS.TLDR102, function() {
-    var errors = lintFile('pages/failing/102.md').errors;
+    let errors = lintFile('pages/failing/102.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR102')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR103\t' + linter.ERRORS.TLDR103, function() {
-    var errors = lintFile('pages/failing/103.md').errors;
+    let errors = lintFile('pages/failing/103.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR103')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
   it('TLDR104\t' + linter.ERRORS.TLDR104, function() {
-    var errors = lintFile('pages/failing/104.md').errors;
+    let errors = lintFile('pages/failing/104.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR104')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
   it('TLDR105\t' + linter.ERRORS.TLDR105, function() {
-    var errors = lintFile('pages/failing/105.md').errors;
+    let errors = lintFile('pages/failing/105.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR105')).toBeTruthy();
     expect(errors.length).toBe(2);
   });
 
   it('TLDR106\t' + linter.ERRORS.TLDR106, function() {
-    var errors = lintFile('pages/failing/106.md').errors;
+    let errors = lintFile('pages/failing/106.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR106')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR107\t' + linter.ERRORS.TLDR107, function() {
-    var errors = lintFile('pages/failing/107').errors;
+    let errors = lintFile('pages/failing/107').errors;
     expect(containsOnlyErrors(errors, 'TLDR107')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR108\t' + linter.ERRORS.TLDR108, function () {
-    var errors = lintFile('pages/failing/108 .md').errors;
+    let errors = lintFile('pages/failing/108 .md').errors;
     expect(containsOnlyErrors(errors, 'TLDR108')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
 
   it('TLDR109\t' + linter.ERRORS.TLDR109, function () {
-    var errors = lintFile('pages/failing/109A.md').errors;
+    let errors = lintFile('pages/failing/109A.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR109')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
@@ -171,34 +171,34 @@ describe('Common TLDR formatting errors', function() {
 
 describe('TLDR pages that are simply correct', function() {
   it('Multiple description lines', function() {
-    var errors = lintFile('pages/passing/descriptions.md').errors;
+    let errors = lintFile('pages/passing/descriptions.md').errors;
     expect(errors.length).toBe(0);
   });
 
   it('Example starting with a bracket', function() {
-    var errors = lintFile('pages/passing/bracket.md').errors;
+    let errors = lintFile('pages/passing/bracket.md').errors;
     expect(errors.length).toBe(0);
   });
 
   it('Example starting with an upper cased unicode character', function() {
-    var errors = lintFile('pages/passing/special-characters.md').errors;
+    let errors = lintFile('pages/passing/special-characters.md').errors;
     expect(errors.length).toBe(0);
   });
 
   it('Page filename and title includes + symbol', function() {
-    var errors = lintFile('pages/passing/title++.md').errors;
+    let errors = lintFile('pages/passing/title++.md').errors;
     expect(errors.length).toBe(0);
   });
 
   it('Certain words are always written in lower case', function() {
-    var errors = lintFile('pages/passing/lower-case.md').errors;
+    let errors = lintFile('pages/passing/lower-case.md').errors;
     expect(errors.length).toBe(0);
   });
 });
 
 describe('ignore errors', function() {
   it('ignore TLDR014', function() {
-    var errors = lintFile('pages/failing/004.md', 'TLDR014').errors;
+    let errors = lintFile('pages/failing/004.md', 'TLDR014').errors;
     expect(containsOnlyErrors(errors, 'TLDR004')).toBeTruthy();
     expect(errors.length).toBe(2);
   });


### PR DESCRIPTION
PR replaces all usages of `var` in the codebase with `const` or `let` as appropriate. No reason to not start looking to modernize the codebase a bit given we have no obligation to support ancient versions of Node that don't support `let` or `const`.