### PR TITLE
Set node 14 as minimum supported version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
 
     name: Node ${{ matrix.node-version }} - ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "name": "tldr-pages team"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
PR drops support for node 12 as it's reached end of life and is no longer supported. I've also replace node 17 with node 18 in the test matrix as the former is also end of life and the latter is the upcoming LTS release so we should verify it works. However, since we're not making any changes to explicitly support node 18 and that node 17 isn't LTS, I don't think we need to call this change out in a separate commit.