### PR TITLE
Remove defunct david-dm badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![npm version][npm-image]][npm-url]
 [![Build Status][github-actions-image]][github-actions-url]
-[![David DM Dependency Status][dep-image]][dep-url]
 [![Gitter chat][gitter-image]][gitter-url]
 
 `tldr-lint` is a linting tool for validating [tldr](https://github.com/tldr-pages/tldr) pages.


### PR DESCRIPTION
PR removes the david-dm badge from the README as the service has been down since at least January and there's no word from the maintainer if or when it could possibly return. With dependabot also making PRs for any out of date dependency, we also shouldn't have any out of date deps anyway.