### PR TITLE
fix: change short version of --ignore from -i to -I

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Options:
   -f, --format         also attempt formatting (to stdout, or as specified by -o)
   -o, --output <file>  output to formatted file
   -i, --in-place       formats in place
+  -t, --tabular        format errors in a tabular format
   -v, --verbose        print verbose output
-  -h, --help           output usage information
+  -I, --ignore <codes> ignore comma separated tldr-lint error codes (e.g. "TLDR001,TLDR0014")
+  -h, --help           display help for command
 ```
 
 ## Linter errors

--- a/lib/tldr-lint-cli.js
+++ b/lib/tldr-lint-cli.js
@@ -100,7 +100,7 @@ if (require.main === module) {
     .option('-i, --in-place', 'formats in place')
     .option('-t, --tabular', 'format errors in a tabular format')
     .option('-v, --verbose', 'print verbose output')
-    .option('-i, --ignore <codes>', 'ignore comma separated tldr-lint error codes (e.g. "TLDR001,TLDR0014")')
+    .option('-I, --ignore <codes>', 'ignore comma separated tldr-lint error codes (e.g. "TLDR001,TLDR0014")')
     .parse(process.argv);
 
   if (program.args.length !== 1) {


### PR DESCRIPTION
So it doesn't clash with the short version of `--in-place`.

And updated readme to include this and other missed options.