### PR TITLE
feat: add tldr 020: spelling of "Note: "

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ TLDR016     | Label for information link should be spelled exactly `More informa
 TLDR017     | Information link should be surrounded with angle brackets
 TLDR018     | Page should only include a single information link
 TLDR019     | Page should only include a maximum of 8 examples
+TLDR020     | Label for additional notes should be spelled exactly `Note: `
 TLDR101     | Command description probably not properly annotated
 TLDR102     | Example description probably not properly annotated
 TLDR103     | Command example is missing its closing backtick

--- a/lib/tldr-lint.js
+++ b/lib/tldr-lint.js
@@ -25,6 +25,7 @@ module.exports.ERRORS = parser.ERRORS = {
   'TLDR017': 'Information link should be surrounded with angle brackets',
   'TLDR018': 'Page should only include a single information link',
   'TLDR019': 'Page should only include a maximum of 8 examples',
+  'TLDR020': 'Label for additional notes should be spelled exactly `Note: `',
 
   'TLDR101': 'Command description probably not properly annotated',
   'TLDR102': 'Example description probably not properly annotated',

--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -753,6 +753,9 @@ case 9:
     yy_.yytext = this.matches[1];
     if (!yy_.yytext.match(/^[\p{Lu}\[]/u)) yy.error(yy_.yylloc, 'TLDR015');
     if (this.matches[2] !== ':') yy.error(yy_.yylloc, 'TLDR005');
+    if (yy_.yytext.match(/(note|NOTE): /)) {
+      yy.error(yy_.yylloc, 'TLDR020');
+    }
     // Try to ensure that verbs at the beginning of the description are in the infinitive tense
     // 1. Any word at the start of a sentence that ends with "ing" and is 6 or more characters long (e.g. executing, writing) is likely a verb in the gerund
     // 2. Any word at the start of a sentence that doesn't end with "us", "ss", or "ys" (e.g. superfluous, success, always) is likely a verb in the present tense

--- a/lib/tldr-parser.js
+++ b/lib/tldr-parser.js
@@ -729,6 +729,9 @@ case 8:
     if (!exceptions.includes(yy_.yytext.replace(/ .*/,'')) && yy_.yytext.match(/^[a-z]/)) {
       yy.error(yy_.yylloc, 'TLDR003');
     }
+    if (yy_.yytext.match(/(note|NOTE): /)) {
+      yy.error(yy_.yylloc, 'TLDR020');
+    }
     var punctuation = this.matches[2];
     if (punctuation !== '.') {
       yy.error(yy_.yylloc, 'TLDR004');

--- a/specs/pages/failing/020.md
+++ b/specs/pages/failing/020.md
@@ -4,6 +4,6 @@
 > NOTE: this should not pass.
 > More information: <https://docs.docker.com/engine/reference/commandline/container/>.
 
-- Example 1:
+- Example 1 (note: this should error):
 
 `demo`

--- a/specs/pages/failing/020.md
+++ b/specs/pages/failing/020.md
@@ -1,0 +1,9 @@
+# demo
+
+> Sample program (note: this should error).
+> NOTE: this should not pass.
+> More information: <https://docs.docker.com/engine/reference/commandline/container/>.
+
+- Example 1:
+
+`demo`

--- a/specs/pages/passing/descriptions.md
+++ b/specs/pages/passing/descriptions.md
@@ -1,5 +1,5 @@
 # du
 
 > Estimate file space usage.
-> This just goes on.
+> This just goes on (Note: this is a note).
 > Because its so important.

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -115,7 +115,7 @@ describe('TLDR conventions', function() {
   it('TLDR020\t' + linter.ERRORS.TLDR020, function() {
     let errors = lintFile('pages/failing/020.md').errors;
     expect(containsOnlyErrors(errors, 'TLDR020')).toBeTruthy();
-    expect(errors.length).toBe(2);
+    expect(errors.length).toBe(3);
   });
 });
 

--- a/specs/tldr-lint.spec.js
+++ b/specs/tldr-lint.spec.js
@@ -111,6 +111,12 @@ describe('TLDR conventions', function() {
     expect(containsOnlyErrors(errors, 'TLDR019')).toBeTruthy();
     expect(errors.length).toBe(1);
   });
+
+  it('TLDR020\t' + linter.ERRORS.TLDR020, function() {
+    let errors = lintFile('pages/failing/020.md').errors;
+    expect(containsOnlyErrors(errors, 'TLDR020')).toBeTruthy();
+    expect(errors.length).toBe(2);
+  });
 });
 
 describe('Common TLDR formatting errors', function() {

--- a/tldr.l
+++ b/tldr.l
@@ -129,6 +129,9 @@ space [ \t]
     if (!exceptions.includes(yytext.replace(/ .*/,'')) && yytext.match(/^[a-z]/)) {
       yy.error(yylloc, 'TLDR003');
     }
+    if (yytext.match(/(note|NOTE): /)) {
+      yy.error(yylloc, 'TLDR020');
+    }
     var punctuation = this.matches[2];
     if (punctuation !== '.') {
       yy.error(yylloc, 'TLDR004');

--- a/tldr.l
+++ b/tldr.l
@@ -155,6 +155,9 @@ space [ \t]
     yytext = this.matches[1];
     if (!yytext.match(/^[\p{Lu}\[]/u)) yy.error(yylloc, 'TLDR015');
     if (this.matches[2] !== ':') yy.error(yylloc, 'TLDR005');
+    if (yytext.match(/(note|NOTE): /)) {
+      yy.error(yylloc, 'TLDR020');
+    }
     // Try to ensure that verbs at the beginning of the description are in the infinitive tense
     // 1. Any word at the start of a sentence that ends with "ing" and is 6 or more characters long (e.g. executing, writing) is likely a verb in the gerund
     // 2. Any word at the start of a sentence that doesn't end with "us", "ss", or "ys" (e.g. superfluous, success, always) is likely a verb in the present tense


### PR DESCRIPTION
closes #298

The linter now rejects "NOTE:" and "note" in the page description and example descriptions.

It does not reject other misspellings like "NoTe:", because 1) I doubt anyone would make such misspellings without actively trying to be disruptive 2) those are easily caught by human reviewers.

Again, I added a unit test and ran the new linter against the entire database.