### PR TITLE
fix: annotation warnings for "LegacyKeyValueFormat" in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@
 FROM node:lts-alpine AS build
 
 # Image metadata
-LABEL org.opencontainers.image.title "tldr-lint Image"
-LABEL org.opencontainers.image.description "This image contains the latest version \
+LABEL org.opencontainers.image.title="tldr-lint Image"
+LABEL org.opencontainers.image.description="This image contains the latest version \
 of the tldr-lint package preinstalled."
-LABEL org.opencontainers.image.source "https://github.com/tldr-pages/tldr-lint"
-LABEL org.opencontainers.image.authors "tldr-pages maintainers and contributors"
-LABEL org.opencontainers.image.vendor "tldr.sh"
-LABEL org.opencontainers.image.licenses "MIT"
+LABEL org.opencontainers.image.source="https://github.com/tldr-pages/tldr-lint"
+LABEL org.opencontainers.image.authors="tldr-pages maintainers and contributors"
+LABEL org.opencontainers.image.vendor="tldr.sh"
+LABEL org.opencontainers.image.licenses="MIT"
 
 # Create app directory
 WORKDIR /app


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e3829c23-8dbd-4776-95d8-663d0be76016)

https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/